### PR TITLE
fanat_training_stash_found_0 text fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Hip quest rewrite/gamedata/configs/text/eng/st_dialogs_escape.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Hip quest rewrite/gamedata/configs/text/eng/st_dialogs_escape.xml
@@ -164,13 +164,13 @@
 	</string>
 
 	<string id="fanat_training_stash_found_0">
-		<text>Found it... Thanks for the artefact.</text>
+		<text>Found it... it was empty though.</text>
 	</string>
 	<!--string id="fanat_training_stash_found_1">
 		<text>Huh... I see that with your level of perception, the Zone won't be taking you so easily. Your final lesson is about to start. Take some time to prepare.</text>
 	</string-->
 	<string id="fanat_training_stash_found_1">
-		<text>Huh... I see that with your level of perception, the Zone won't be taking you so easily. That was your final lesson. You've certainly proven to be your own stalker, and you should be proud of it. There's nothing more I can teach you.</text>
+		<text>Huh... I see that with your level of perception, the Zone won't be taking you so easily. And yep, that 'nest' supposed to be empty, you'll find your real treasures later. That was your final lesson. You've certainly proven to be your own stalker, and you should be proud of it. There's nothing more I can teach you.</text>
 	</string>
 	
 	<string id="fanat_training_bandit_raid_start_0">

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Hip quest rewrite/gamedata/configs/text/rus/st_dialogs_escape.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Hip quest rewrite/gamedata/configs/text/rus/st_dialogs_escape.xml
@@ -164,13 +164,13 @@
 	</string>
 
 	<string id="fanat_training_stash_found_0">
-		<text>Я нашёл тайник. Спасибо за артефакт.</text>
+		<text>Я нашёл тайник... правда, он пустой.</text>
 	</string>
 	<!--string id="fanat_training_stash_found_1">
 		<text>Huh... I see that with your level of perception, the Zone won't be taking you so easily. Your final lesson is about to start. Take some time to prepare.</text>
 	</string-->
 	<string id="fanat_training_stash_found_1">
-		<text>Что ж, сталкер, чую, с твоей внимательностью и прытью в Зоне ты не пропадёшь... Это был твой последний урок - всё, чему я мог научить тебя. Ты определённо доказал, что вправе называть себя сталкером, так что можешь смело радоваться.</text>
+		<text>Ну, сталкер, чую, с твоей внимательностью и прытью в Зоне ты не пропадёшь... И да, "на антресолях" ничего и не должно было быть. Настоящие схроны тебе ещё предстоит отыскивать самому. Что ж, это был твой последний урок - всё, чему я мог научить тебя. Ты определённо доказал, что вправе называть себя сталкером, так что можешь смело радоваться.</text>
 	</string>
 	
 	<string id="fanat_training_bandit_raid_start_0">


### PR DESCRIPTION
Since this stash supposed to be empty and entire quest purpose is to "teach how to find", I've altered both lang dialogues to actually be in line with such events, not mentioning any artefact. Makes more sense.

![изображение](https://user-images.githubusercontent.com/60776130/162409754-44d1744f-2353-43be-8555-0671f42cd3c4.png)

Suggestion for the future: since this quest doesn't have any reward at all for now, it could provide coordinates for the "real stash" as one. This will require to alter said dialogues once again.