### PR TITLE
Allow the Svarog detector to detect DAO anomalies

### DIFF
--- a/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/items/items/items_devices.ltx
+++ b/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/items/items/items_devices.ltx
@@ -1,0 +1,1269 @@
+
+;;--===========================================
+;;--================| Devices |================
+;;--===========================================
+
+
+[tch_device]	;;-- (base)
+kind								                   = i_device
+class                                                  = II_ATTCH
+script_binding                                         = item_device.bind
+use_condition                            		       = true
+auto_attach                                            = false 
+allow_repair                             		       = false
+anim_item                                              = false
+release_on_first_update							       = false
+
+power_critical							 		       = 0.05
+condition_bar									       = power_progess_bar
+use2_functor                					       = item_device.menu_battery
+use2_action_functor         					       = item_device.func_battery
+
+[tch_detector]:identity_immunities,tch_device
+GroupControlSection                                    = spawn_group
+$spawn                                                 = "devices\detector_simple"
+$prefetch                                              = 32
+class                                                  = DET_SIMP
+cform                                                  = skeleton
+visual                                                 = dynamics\devices\dev_detector_1\dev_detector_1.ogf
+hud                                                    = detector_simple_hud
+animation_slot                                         = 7
+inv_name                                               = st_detector1
+inv_name_short                                         = st_detector1
+description                                            = st_detector1_descr
+slot                                                   = 8
+ef_detector_type                                       = 1
+inv_weight                                             = 0.44
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 2
+inv_grid_y                                             = 5
+cost                                                   = 100
+default_to_ruck                                        = true
+af_radius			                                   = 0
+af_vis_radius		                                   = 0
+tier                                                   = 1
+
+attach_angle_offset                                    = -1.303,-1.493,-1.202
+attach_position_offset                                 = 0.110,-0.019,0.000
+attach_bone_name                                       = bip01_l_hand
+auto_attach                                            = false
+snd_draw                                               = weapons\detector\detector_draw
+snd_holster                                            = weapons\detector\detector_holster
+
+particles_enabled                                      = false
+hud_particles_enabled                                  = false
+particles                                              = none
+particles_bone                                         = bone01
+
+
+;;--==========================< PDA >=============================
+[device_pda_1]:device_pda,tch_device
+GroupControlSection                                    = spawn_group
+discovery_dependency                                   =
+$spawn                                                 = "devices\pda"
+$prefetch                                              = 16
+class                                                  = D_PDA
+cform                                                  = skeleton
+visual                                                 = dynamics\devices\dev_pda\dev_pda.ogf
+description                                            = st_pda_1_descr
+radius                                                 = 68	
+slot                                                   = 7
+hud                                      			   = device_pda_1_hud
+default_to_ruck                          		       = true ;false
+sprint_allowed                                         = true
+control_inertion_factor                                = 1
+animation_slot             							   = 13
+; script_binding                                       = bind_physic_object.init
+inv_name                                               = st_pda_1_name
+inv_name_short                                         = st_pda_1_name
+inv_weight                                             = 0.1
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 4
+inv_grid_y                                             = 27
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 0
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost                                                   = 4000
+attach_angle_offset                                    = -1.303,0.107,-1.702
+attach_position_offset                                 = 0.14,0.001,0.02
+attach_bone_name                                       = bip01_l_hand
+auto_attach                                            = false
+tier                                                   = 2
+
+hud_fov												   = 0.68
+[device_pda_1_hud]:pda_hud
+item_visual                                            = dynamics\devices\dev_pda\dev_pda_green_hud.ogf
+
+hands_position			                               = -0.005, -0.095, -0.02
+hands_position_16x9		                               = -0.005, -0.095, -0.02
+hands_orientation		                               = 0, -5.2, -0.65
+hands_orientation_16x9	                               = 0, -5.2, -0.65
+
+aim_hud_offset_pos         							   = 0.01, -0.04, -0.127
+aim_hud_offset_pos_16x9								   = 0.01, -0.04, -0.127
+aim_hud_offset_rot        							   = -0.515, -0.034, 0
+aim_hud_offset_rot_16x9								   = -0.515, -0.034, 0
+
+;------------------------
+[device_pda_2]:device_pda_1
+visual                                                 = dynamics\devices\dev_pda\dev_pda_2.ogf
+radius                                                 = 120
+inv_grid_x                                             = 5
+cost                                                   = 25000
+description                                            = st_pda_2_descr
+inv_name                                               = st_pda_2_name
+inv_name_short                                         = st_pda_2_name
+tier                                                   = 4
+hud                                      			   = device_pda_2_hud
+
+[device_pda_2_hud]:pda_hud
+item_visual                                            = dynamics\devices\dev_pda\dev_pda_blue_hud.ogf
+
+hands_position			                               = -0.005, -0.095, -0.02
+hands_position_16x9		                               = -0.005, -0.095, -0.02
+hands_orientation		                               = 0, -5.2, -0.65
+hands_orientation_16x9	                               = 0, -5.2, -0.65
+
+aim_hud_offset_pos         							   = 0.01, -0.04, -0.127
+aim_hud_offset_pos_16x9								   = 0.01, -0.04, -0.127
+aim_hud_offset_rot        							   = -0.515, -0.034, 0
+aim_hud_offset_rot_16x9								   = -0.515, -0.034, 0
+
+;------------------------
+[device_pda_3]:device_pda_1
+visual                                                 = dynamics\devices\dev_pda\dev_pda_3.ogf
+radius                                                 = 240
+inv_grid_x                                             = 6
+cost                                                   = 50000
+description                                            = st_pda_3_descr
+inv_name                                               = st_pda_3_name
+inv_name_short                                         = st_pda_3_name
+tier                                                   = 5
+hud                                      			   = device_pda_3_hud
+
+[device_pda_3_hud]:pda_hud
+item_visual                                            = dynamics\devices\dev_pda\dev_pda_black_hud.ogf
+
+hands_position			                               = -0.005, -0.095, -0.02
+hands_position_16x9		                               = -0.005, -0.095, -0.02
+hands_orientation		                               = 0, -5.2, -0.65
+hands_orientation_16x9	                               = 0, -5.2, -0.65
+
+aim_hud_offset_pos         							   = 0.01, -0.04, -0.127
+aim_hud_offset_pos_16x9								   = 0.01, -0.04, -0.127
+aim_hud_offset_rot        							   = -0.515, -0.034, 0
+aim_hud_offset_rot_16x9								   = -0.515, -0.034, 0
+
+;;--==========================< common PDA and Flashdrives >=============================
+[itm_pda_common]:device_pda_1
+description                                            = st_pda_mlr_descr
+inv_name                                               = st_pda_name
+inv_name_short                                         = st_pda_name
+inv_weight                                             = 0.1
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 7
+inv_grid_y                                             = 3
+cost                                                   = 0
+use1_functor                					       = ui_pda_npc_tab.menu_view
+use1_action_functor         					       = ui_pda_npc_tab.use_view
+
+[itm_pda_uncommon]:itm_pda_common
+
+[itm_pda_rare]:itm_pda_uncommon
+
+;-- (not used)
+[itm_guide_usb_1]:booster
+can_trade                                              = false
+description                                            = st_pda_descr
+inv_grid_x                                             = 8
+inv_grid_y                                             = 3
+inv_name                                               = st_memory_stick_name
+inv_name_short                                         = st_memory_stick_name
+class                                                  = II_FOOD
+kind								                   = i_device
+
+[itm_guide_usb_2]:booster
+can_trade                                              = false
+description                                            = st_pda_descr
+inv_grid_x                                             = 9
+inv_grid_y                                             = 3
+inv_name                                               = st_memory_stick_name
+inv_name_short                                         = st_memory_stick_name
+class                                                  = II_FOOD
+kind								                   = i_device
+
+
+;;--==========================< Detectors >=============================
+[detector_base_hud]:hud_base
+attach_place_idx		                               = 1
+
+;--from beretta
+hands_position			                               = 0.055, -0.425, -0.23
+hands_position_16x9		                               = 0.055, -0.425, -0.23
+hands_orientation		                               = -1, 25, -1
+hands_orientation_16x9	                               = -1, 25, -1
+
+aim_hud_offset_pos         							   = -0.18, 0.14, 0.15
+aim_hud_offset_pos_16x9								   = -0.18, 0.14, 0.15
+aim_hud_offset_rot          						   = 0.3, 0.13, -0.015
+aim_hud_offset_rot_16x9     						   = 0.3, 0.13, -0.015
+
+gl_hud_offset_pos			                           = 0,0,0
+gl_hud_offset_rot			                           = 0,0,0
+
+lean_hud_offset_pos		                               = 0,0,0
+lean_hud_offset_rot		                               = 0,0,0
+
+freelook_z_offset_mul								   = 0.1
+
+
+;;--======< Echo detector >======--
+[detector_simple]:identity_immunities,tch_device
+GroupControlSection	                                   = spawn_group
+$spawn 			                                       = "devices\detector_simple"
+$prefetch 		                                       = 32
+class			                                       = DET_SIMP
+cform			                                       = skeleton
+visual			                                       = dynamics\devices\dev_detector_1\dev_detector_1.ogf
+hud			                                           = detector_simple_hud
+animation_slot		                                   = 7
+inv_name		                                       = st_detector1
+inv_name_short	                                       = st_detector1
+description		                                       = st_detector1_descr
+slot			                                       = 8
+ef_detector_type	                                   = 1
+inv_weight		                                       = 0.44
+inv_grid_width		                                   = 1
+inv_grid_height		                                   = 1
+inv_grid_x		                                       = 8
+inv_grid_y		                                       = 27
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 600
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost			                                       = 3460
+default_to_ruck		                                   = true
+af_radius		                                       = 30
+af_vis_radius		                                   = 3
+tier                                                   = 2
+
+----------------(Rank 0 \ Junk)
+af_class_1		                                       = af_dragon_eye
+af_sound_1_		                                       = detectors\art_beep1
+af_freq_1		                                       = 0.05, 2
+
+af_class_2		                                       = af_fire_loop
+af_sound_2_		                                       = detectors\art_beep1
+af_freq_2		                                       = 0.05, 2
+
+af_class_3		                                       = af_ball
+af_sound_3_		                                       = detectors\art_beep1
+af_freq_3		                                       = 0.05, 2
+
+af_class_4		                                       = af_fonar
+af_sound_4_		                                       = detectors\art_beep1
+af_freq_4		                                       = 0.05, 2
+
+af_class_5		                                       = af_tapeworm
+af_sound_5_		                                       = detectors\art_beep1
+af_freq_5		                                       = 0.05, 2
+
+af_class_6		                                       = af_moh
+af_sound_6_		                                       = detectors\art_beep1
+af_freq_6		                                       = 0.05, 2
+
+af_class_7		                                       = af_serofim
+af_sound_7_		                                       = detectors\art_beep1
+af_freq_7		                                       = 0.05, 2
+
+af_class_8		                                       = af_elektron
+af_sound_8_		                                       = detectors\art_beep1
+af_freq_8		                                       = 0.05, 2
+
+af_class_9		                                       = af_kogot
+af_sound_9_		                                       = detectors\art_beep1
+af_freq_9		                                       = 0.05, 2
+
+af_class_10		                                       = af_generator
+af_sound_10_		                                   = detectors\art_beep1
+af_freq_10		                                       = 0.05, 2
+
+af_class_11		                                       = af_black_angel
+af_sound_11_		                                   = detectors\art_beep1
+af_freq_11		                                       = 0.05, 2
+
+af_class_19		                                       = af_grapes
+af_sound_19_		                                   = detectors\art_beep1
+af_freq_19		                                       = 0.05, 2
+
+af_class_20		                                       = af_skull_miser
+af_sound_20_		                                   = detectors\art_beep1
+af_freq_20		                                       = 0.05, 2
+
+af_class_21		                                       = af_star_phantom
+af_sound_21_		                                   = detectors\art_beep1
+af_freq_21		                                       = 0.05, 2
+
+af_class_22		                                       = af_medallion
+af_sound_22_		                                   = detectors\art_beep1
+af_freq_22		                                       = 0.05, 2
+
+af_class_23		                                       = af_peas
+af_sound_23_		                                   = detectors\art_beep1
+af_freq_23		                                       = 0.05, 2
+
+af_class_24		                                       = af_kislushka
+af_sound_24_		                                   = detectors\art_beep1
+af_freq_24		                                       = 0.05, 2
+
+af_class_25		                                       = af_zhelch
+af_sound_25_		                                   = detectors\art_beep1
+af_freq_25		                                       = 0.05, 2
+
+af_class_26		                                       = af_sandstone
+af_sound_26_		                                   = detectors\art_beep1
+af_freq_26		                                       = 0.05, 2
+
+af_class_12		                                       = af_fountain
+af_sound_12_		                                   = detectors\art_beep1
+af_freq_12		                                       = 0.05, 2
+
+af_class_13		                                       = af_spaika
+af_sound_13_		                                   = detectors\art_beep1
+af_freq_13		                                       = 0.05, 2
+
+af_class_14		                                       = af_signet
+af_sound_14_		                                   = detectors\art_beep1
+af_freq_14		                                       = 0.05, 2
+
+af_class_15		                                       = af_repei
+af_sound_15_		                                   = detectors\art_beep1
+af_freq_15		                                       = 0.05, 2
+
+af_class_16		                                       = af_bat
+af_sound_16_		                                   = detectors\art_beep1
+af_freq_16		                                       = 0.05, 2
+
+af_class_17		                                       = af_sun
+af_sound_17_		                                   = detectors\art_beep1
+af_freq_17		                                       = 0.05, 2
+
+af_class_18		                                       = af_ear
+af_sound_18_		                                   = detectors\art_beep1
+af_freq_18		                                       = 0.05, 2
+
+af_class_27		                                       = af_chelust
+af_sound_27_		                                   = detectors\art_beep1
+af_freq_27		                                       = 0.05, 2
+
+af_class_28		                                       = af_atom
+af_sound_28_	                                       = detectors\art_beep1
+af_freq_28		                                       = 0.05, 2
+
+af_class_29		                                       = af_lighthouse
+af_sound_29_	                                       = detectors\art_beep1
+af_freq_29		                                       = 0.05, 2
+
+af_class_30		                                       = af_cell
+af_sound_30_	                                       = detectors\art_beep1
+af_freq_30		                                       = 0.05, 2
+
+af_class_31		                                       = af_cocoon
+af_sound_31_	                                       = detectors\art_beep1
+af_freq_31		                                       = 0.05, 2
+
+
+----------------(Special)
+af_class_32		                                       = jup_b1_half_artifact
+af_sound_32_	                                       = detectors\art_beep1
+af_freq_32		                                       = 0.05, 2
+
+;af_class_33		                                   = af_quest_b14_twisted
+;af_sound_33_	                                       = detectors\art_beep1
+;af_freq_33		                                       = 0.05, 2
+
+af_class_33		                                       = af_monolith
+af_sound_33_	                                       = detectors\art_beep1
+af_freq_33		                                       = 0.05, 2
+
+af_class_34		                                       = af_compass
+af_sound_34_	                                       = detectors\art_beep1
+af_freq_34		                                       = 0.05, 2
+
+af_class_35		                                       = af_oasis_heart
+af_sound_35_	                                       = detectors\art_beep1
+af_freq_35		                                       = 0.05, 2
+
+----------------(Rank 1)
+af_class_36		                                       = af_itcher
+af_sound_36_	                                       = detectors\art_beep1
+af_freq_36		                                       = 0.05, 2
+
+af_class_37		                                       = af_pin
+af_sound_37_	                                       = detectors\art_beep1
+af_freq_37		                                       = 0.05, 2
+
+af_class_38		                                       = af_blood
+af_sound_38_	                                       = detectors\art_beep1
+af_freq_38		                                       = 0.05, 2
+
+af_class_39		                                       = af_mincer_meat
+af_sound_39_		                                   = detectors\art_beep1
+af_freq_39		                                       = 0.05, 2
+
+af_class_40		                                       = af_electra_sparkler
+af_sound_40_	                                       = detectors\art_beep1
+af_freq_40		                                       = 0.05, 2
+
+af_class_41		                                       = af_sponge
+af_sound_41_	                                       = detectors\art_beep1
+af_freq_41		                                       = 0.05, 2
+
+af_class_42		                                       = af_cristall_flower
+af_sound_42_	                                       = detectors\art_beep1
+af_freq_42		                                       = 0.05, 2
+
+af_class_43		                                       = af_lobster_eyes
+af_sound_43_	                                       = detectors\art_beep1
+af_freq_43		                                       = 0.05, 2
+
+af_class_44		                                       = af_medusa
+af_sound_44_	                                       = detectors\art_beep1
+af_freq_44		                                       = 0.05, 2
+
+af_class_45		                                       = af_night_star
+af_sound_45_	                                       = detectors\art_beep1
+af_freq_45		                                       = 0.05, 2
+
+af_class_46		                                       = af_dummy_glassbeads
+af_sound_46_	                                       = detectors\art_beep1
+af_freq_46		                                       = 0.05, 2
+
+af_class_47		                                       = af_dummy_battery
+af_sound_47_	                                       = detectors\art_beep1
+af_freq_47		                                       = 0.05, 2
+
+af_class_48		                                       = af_soul
+af_sound_48_	                                       = detectors\art_beep1
+af_freq_48		                                       = 0.05, 2
+
+
+attach_angle_offset		                               = -1.303,-1.493,-1.202
+attach_position_offset	                               = 0.110,-0.019,0.000
+attach_bone_name	                                   = bip01_l_hand
+auto_attach		                                       = false
+snd_draw                                               = weapons\detector\detector_draw
+snd_holster                                            = weapons\detector\detector_holster
+
+[detector_simple_hud]:detector_base_hud
+item_position				                           = -0.072424,0.030392,-0.012213
+item_orientation			                           = 324.640503,-189.627350,-183.009415
+
+hands_position			                               = 0.06, -0.42, -0.11
+hands_position_16x9		                               = 0.06, -0.42, -0.11
+hands_orientation		                               = 0, 25, -1
+hands_orientation_16x9	                               = 0, 25, -1
+
+aim_hud_offset_pos         							   = -0.18, 0.11, 0.06
+aim_hud_offset_pos_16x9								   = -0.18, 0.11, 0.06
+aim_hud_offset_rot          						   = 0.1, 0.15, -0.015
+aim_hud_offset_rot_16x9     						   = 0.1, 0.15, -0.015
+
+item_visual                   	                       = dynamics\devices\dev_detector_1\dev_detector_1_hud
+
+fire_point			                                   = 0,0,-0.05
+fire_bone      	      		                           = light_bone_2
+fire_point2			                                   = 0,0,0
+fire_bone2			                                   = light_bone_1
+
+anm_show					                           = d1_draw, draw
+anm_show_fast				                           = d1_draw, draw, 1.5
+anm_hide					                           = d1_holster, holster
+anm_hide_fast				                           = d1_holster, holster, 1.5
+anm_idle					                           = d1_idle, idle
+anm_idle_moving				                           = d1_move, move
+anm_idle_moving_crouch		                           = d1_crouch, move
+anm_idle_sprint				                           = d1_sprint, sprint
+
+anm_idle_zoom										   = d1_zoom, idle
+anm_zoom								               = d1_zoom_in, idle
+anm_zoom_show							               = d1_zoom_draw, idle, 1.5
+anm_zoom_hide							               = d1_zoom_holster, idle, 1.5
+anm_zoom_hide_fast						               = d1_zoom_holster, idle, 2
+
+anm_throw_start										   = d1_throw_start, idle
+anm_throw											   = d1_throw_idle, idle
+anm_throw_end										   = d1_throw_end, idle
+
+flash_light_range		                               = 0.1
+onoff_light_range		                               = 0.1
+
+;;--======< Bear detector >======--
+[detector_advanced]:detector_simple
+$spawn 			                                       = "devices\detector_advanced"
+class			                                       = DET_ADVA
+visual			                                       = dynamics\devices\dev_detector_2\dev_detector_2.ogf
+inv_name		                                       = st_detector2
+inv_name_short	                                       = st_detector2
+description		                                       = st_detector2_descr
+inv_weight		                                       = 0.36
+inv_grid_width	                                       = 1
+inv_grid_height	                                       = 1
+inv_grid_x		                                       = 9
+inv_grid_y		                                       = 27
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 500
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost			                                       = 7480
+hud			                                           = detector_advanced_hud
+af_radius		                                       = 30
+af_vis_radius		                                   = 4
+tier                                                   = 3
+
+----------------(Rank 2)
+af_class_49		                                       = af_cristall
+af_sound_49_	                                       = detectors\art_beep1
+af_freq_49		                                       = 0.05, 2
+
+af_class_50		                                       = af_bracelet
+af_sound_50_	                                       = detectors\art_beep1
+af_freq_50		                                       = 0.05, 2
+
+af_class_51		                                       = af_ring
+af_sound_51_	                                       = detectors\art_beep1
+af_freq_51		                                       = 0.05, 2
+
+af_class_52		                                       = af_electra_moonlight
+af_sound_52_	                                       = detectors\art_beep1
+af_freq_52		                                       = 0.05, 2
+
+af_class_53		                                       = af_vyvert
+af_sound_53_	                                       = detectors\art_beep1
+af_freq_53		                                       = 0.05, 2
+
+af_class_54		                                       = af_empty
+af_sound_54_	                                       = detectors\art_beep1
+af_freq_54		                                       = 0.05, 2
+
+af_class_55		                                       = af_gravi
+af_sound_55_	                                       = detectors\art_beep1
+af_freq_55		                                       = 0.05, 2
+
+af_class_56		                                       = af_eye
+af_sound_56_	                                       = detectors\art_beep1
+af_freq_56		                                       = 0.05, 2
+
+af_class_57		                                       = af_dummy_dummy
+af_sound_57_	                                       = detectors\art_beep1
+af_freq_57		                                       = 0.05, 2
+
+af_class_58		                                       = af_fuzz_kolobok
+af_sound_58_	                                       = detectors\art_beep1
+af_freq_58		                                       = 0.05, 2
+
+
+[detector_advanced_hud]:detector_base_hud
+item_position				                           = -0.078949,0.039172,-0.019197
+item_orientation			                           = 320.606964,-194.089020,-186.572464
+
+hands_position			                               = 0.09, -0.44, -0.23
+hands_orientation		                               = -1, 25, -1
+hands_position_16x9		                               = 0.09, -0.44, -0.23
+hands_orientation_16x9	                               = -1, 25, -1
+
+aim_hud_offset_pos         							   = -0.2, 0.17, 0.18
+aim_hud_offset_pos_16x9								   = -0.2, 0.17, 0.18
+aim_hud_offset_rot          						   = 0.4, 0.06, -0.015
+aim_hud_offset_rot_16x9     						   = 0.4, 0.06, -0.015
+
+item_visual                   	                       = dynamics\devices\dev_detector_2\dev_detector_2_hud
+
+anm_show				                               = d2_draw, draw
+anm_show_fast			                               = d2_draw, draw, 1.5
+anm_hide				                               = d2_holster, holster
+anm_hide_fast			                               = d2_holster, holster, 1.5
+anm_idle				                               = d2_idle, idle
+anm_idle_moving			                               = d2_move, move
+anm_idle_moving_crouch	                               = d2_crouch, move
+anm_idle_sprint			                               = d2_sprint, sprint
+
+anm_idle_zoom										   = d2_zoom, idle
+anm_zoom								               = d2_zoom_in, idle
+anm_zoom_show							               = d2_zoom_draw, idle, 1.5
+anm_zoom_hide							               = d2_zoom_holster, idle, 1.5
+anm_zoom_hide_fast						               = d2_zoom_holster, idle, 2
+
+anm_throw_start										   = d2_throw_start, idle
+anm_throw											   = d2_throw_idle, idle
+anm_throw_end										   = d2_throw_end, idle
+
+;;--======< Veles detector >======--
+[detector_elite]:detector_advanced
+$spawn 			                                       = "devices\detector_elite"
+class			                                       = DET_ELIT
+visual			                                       = dynamics\devices\dev_detector_3\dev_detector_3.ogf
+inv_name		                                       = st_detector3
+inv_name_short	                                       = st_detector3
+description		                                       = st_detector3_descr
+hud			                                           = detector_elite_hud
+inv_weight		                                       = 0.29
+inv_grid_width		                                   = 1
+inv_grid_height		                                   = 1
+inv_grid_x		                                       = 10
+inv_grid_y		                                       = 27
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 400
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost			                                       = 46880
+; elite x                                              ="0.00096" y="0.0035"
+ui_p			                                       = -0.02904,0.01,0.0364
+ui_r			                                       = 0,90,0
+af_radius		                                       = 30
+af_vis_radius		                                   = 5
+tier                                                   = 4
+
+----------------(Rank 3)
+af_class_59		                                       = af_fireball
+af_sound_59_		                                   = detectors\art_beep1
+af_freq_59		                                       = 0.05, 2
+
+af_class_60		                                       = af_baloon
+af_sound_60_		                                   = detectors\art_beep1
+af_freq_60		                                       = 0.05, 2
+
+af_class_61		                                       = af_electra_flash
+af_sound_61_		                                   = detectors\art_beep1
+af_freq_61		                                       = 0.05, 2
+
+af_class_62		                                       = af_black_spray
+af_sound_62_		                                   = detectors\art_beep1
+af_freq_62		                                       = 0.05, 2
+
+af_class_63		                                       = af_full_empty
+af_sound_63_		                                   = detectors\art_beep1
+af_freq_63		                                       = 0.05, 2
+
+af_class_64		                                       = af_gold_fish
+af_sound_64_		                                   = detectors\art_beep1
+af_freq_64		                                       = 0.05, 2
+
+af_class_65		                                       = af_fire
+af_sound_65_		                                   = detectors\art_beep1
+af_freq_65		                                       = 0.05, 2
+
+af_class_66		                                       = af_ice
+af_sound_66_		                                   = detectors\art_beep1
+af_freq_66		                                       = 0.05, 2
+
+af_class_67		                                       = af_glass
+af_sound_67_		                                   = detectors\art_beep1
+af_freq_67		                                       = 0.05, 2
+
+af_class_68		                                       = af_death_lamp
+af_sound_68_		                                   = detectors\art_beep1
+af_freq_68		                                       = 0.05, 2
+
+
+[detector_elite_hud]:detector_base_hud
+
+item_position				                           = -0.071685,0.036188,-0.009934
+item_orientation			                           = 314.589233,-186.420761,-189.323669
+
+item_visual                   	                       = dynamics\devices\dev_detector_3\dev_detector_3_hud
+
+anm_show					                           = d3_draw, draw
+anm_show_fast				                           = d3_draw, draw, 1.5
+anm_hide					                           = d3_holster, holster
+anm_hide_fast				                           = d3_holster, holster, 1.5
+anm_idle					                           = d3_idle, idle
+anm_idle_moving				                           = d3_move, move
+anm_idle_moving_crouch		                           = d3_crouch, move
+anm_idle_sprint				                           = d3_sprint, sprint
+
+anm_idle_zoom										   = d3_zoom, idle
+anm_zoom								               = d3_zoom_in, idle
+anm_zoom_show							               = d3_zoom_draw, idle, 1.5
+anm_zoom_hide							               = d3_zoom_holster, idle, 1.5
+anm_zoom_hide_fast						               = d3_zoom_holster, idle, 2
+
+anm_throw_start										   = d3_throw_start, idle
+anm_throw											   = d3_throw_idle, idle
+anm_throw_end										   = d3_throw_end, idle
+
+;;--======< Svarog detector >======--
+[detector_scientific]:detector_elite
+$spawn 				                                   = "devices\detector_scientific"
+class				                                   = DET_SCIE
+visual			                                       = dynamics\devices\dev_detector_4\dev_detector_4.ogf
+inv_name		                                       = st_detector4
+inv_name_short	                                       = st_detector4
+description		                                       = st_detector4_descr
+hud			                                           = detector_scientific_hud
+inv_weight		                                       = 0.28
+inv_grid_width		                                   = 1
+inv_grid_height		                                   = 1
+inv_grid_x		                                       = 11
+inv_grid_y		                                       = 27
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 300
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost			                                       = 98680
+; elite x                                              ="0.00096" y="0.0035"
+ui_p			                                       = -0.02904,0.01,0.0364
+ui_r			                                       = 0,90,0
+af_radius		                                       = 30
+af_vis_radius		                                   = 6
+tier                                                   = 5
+
+zone_class_1		                                   = zone_mine_acidic_weak
+zone_class_2		                                   = zone_mine_acidic_average
+zone_class_3		                                   = zone_mine_acidic_strong
+
+zone_class_4		                                   = zone_mine_electric_weak
+zone_class_5		                                   = zone_mine_electric_average
+zone_class_6		                                   = zone_mine_electric_strong
+
+zone_class_7		                                   = zone_mine_gravitational_weak
+zone_class_8		                                   = zone_mine_gravitational_average
+zone_class_9		                                   = zone_mine_gravitational_strong
+
+zone_class_10		                                   = zone_mine_thermal_weak
+zone_class_11		                                   = zone_mine_thermal_average
+zone_class_12		                                   = zone_mine_thermal_strong
+
+zone_class_13		                                   = zone_mine_steam_weak
+zone_class_14		                                   = zone_mine_steam_average
+zone_class_15		                                   = zone_mine_steam_strong
+
+zone_class_16		                                   = zone_mine_acidic_big
+
+zone_class_17		                                   = zone_mine_chemical_weak
+zone_class_18		                                   = zone_mine_chemical_average
+zone_class_19		                                   = zone_mine_chemical_strong
+
+zone_class_20		                                   = zone_buzz_weak
+zone_class_21		                                   = zone_buzz_average
+zone_class_22		                                   = zone_buzz_strong
+
+zone_class_23		                                   = zone_mine_static_weak
+zone_class_24		                                   = zone_mine_static_average
+zone_class_25		                                   = zone_mine_static_strong
+
+zone_class_26		                                   = zone_witches_galantine_weak
+zone_class_27		                                   = zone_witches_galantine_average
+zone_class_28		                                   = zone_witches_galantine_strong
+
+zone_class_29		                                   = zone_mine_gravitational_big
+
+zone_class_30		                                   = zone_gravi_zone
+
+zone_class_31		                                   = zone_zharka_static_weak
+zone_class_32		                                   = zone_zharka_static_average
+zone_class_33		                                   = zone_zharka_static_strong
+
+zone_class_34		                                   = zone_mosquito_bald
+zone_class_35		                                   = zone_mosquito_bald_weak
+zone_class_36		                                   = zone_mosquito_bald_average
+zone_class_37		                                   = zone_mosquito_bald_strong
+
+zone_class_38										   = zone_mine_darkness
+zone_class_39										   = zone_mine_flash
+zone_class_40										   = zone_mine_ghost
+zone_class_41										   = zone_mine_gold
+zone_class_42										   = zone_mine_green_dragon
+zone_class_43										   = zone_mine_mefistotel
+zone_class_44										   = zone_mine_net
+zone_class_45										   = zone_mine_point
+zone_class_46										   = zone_mine_radar
+zone_class_47										   = zone_mine_sphere
+
+zone_freq_1			                                   = 0.05, 2
+zone_freq_2			                                   = 0.05, 2
+zone_freq_3			                                   = 0.05, 2
+zone_freq_4			                                   = 0.05, 2
+zone_freq_5			                                   = 0.05, 2
+zone_freq_6			                                   = 0.05, 2
+zone_freq_7			                                   = 0.05, 2
+zone_freq_8			                                   = 0.05, 2
+zone_freq_9			                                   = 0.05, 2
+zone_freq_10		                                   = 0.05, 2
+zone_freq_11		                                   = 0.05, 2
+zone_freq_12		                                   = 0.05, 2
+zone_freq_13		                                   = 0.05, 2
+zone_freq_14		                                   = 0.05, 2
+zone_freq_15		                                   = 0.05, 2
+zone_freq_16		                                   = 0.05, 2
+zone_freq_17		                                   = 0.05, 2
+zone_freq_18		                                   = 0.05, 2
+zone_freq_19		                                   = 0.05, 2
+zone_freq_20		                                   = 0.05, 2
+zone_freq_21		                                   = 0.05, 2
+zone_freq_22		                                   = 0.05, 2
+zone_freq_23		                                   = 0.05, 2
+zone_freq_24		                                   = 0.05, 2
+zone_freq_25		                                   = 0.05, 2
+zone_freq_26		                                   = 0.05, 2
+zone_freq_27		                                   = 0.05, 2
+zone_freq_28		                                   = 0.05, 2
+zone_freq_29		                                   = 0.05, 2
+zone_freq_30		                                   = 0.05, 2
+zone_freq_31		                                   = 0.05, 2
+zone_freq_32		                                   = 0.05, 2
+zone_freq_33		                                   = 0.05, 2
+zone_freq_34		                                   = 0.05, 2
+zone_freq_35		                                   = 0.05, 2
+zone_freq_36		                                   = 0.05, 2
+zone_freq_37		                                   = 0.05, 2
+zone_freq_38		                                   = 0.05, 2
+zone_freq_39										   = 0.05, 2
+zone_freq_40										   = 0.05, 2
+zone_freq_41										   = 0.05, 2
+zone_freq_42										   = 0.05, 2
+zone_freq_43										   = 0.05, 2
+zone_freq_44										   = 0.05, 2
+zone_freq_45										   = 0.05, 2
+zone_freq_46										   = 0.05, 2
+zone_freq_47										   = 0.05, 2
+
+[detector_scientific_hud]:detector_base_hud
+
+item_position				                           = -0.071685,0.036188,-0.009934
+item_orientation			                           = 314.589233,-186.420761,-189.323669
+
+item_visual                   	                       = dynamics\devices\dev_detector_4\dev_detector_4_hud
+
+anm_show				                               = d3_draw, draw
+anm_show_fast			                               = d3_draw, draw, 1.5
+anm_hide				                               = d3_holster, holster
+anm_hide_fast			                               = d3_holster, holster, 1.5
+anm_idle				                               = d3_idle, idle
+anm_idle_moving			                               = d3_move, move
+anm_idle_sprint			                               = d3_sprint, sprint
+
+anm_idle_zoom										   = d3_zoom, idle
+anm_zoom								               = d3_zoom_in, idle
+anm_zoom_show							               = d3_zoom_draw, idle, 1.5
+anm_zoom_hide							               = d3_zoom_holster, idle, 1.5
+anm_zoom_hide_fast						               = d3_zoom_holster, idle, 2
+
+anm_throw_start										   = d3_throw_start, idle
+anm_throw											   = d3_throw_idle, idle
+anm_throw_end										   = d3_throw_end, idle
+
+;;--======< Anomaly measurement device >======--
+[detector_anomaly]:tch_detector
+visual                              	               = dynamics\devices\dev_detector_8\dev_detector_8.ogf
+hud                                                    = detector_anomaly_hud
+animation_slot                                         = 7
+inv_name                                               = st_detector8
+inv_name_short                                         = st_detector8
+description                                            = st_detector8_descr
+inv_weight                                             = 0.53
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 8
+inv_grid_y                                             = 28
+cost                                                   = 2700
+default_to_ruck                                        = true
+can_trade                                              = false
+snd_draw                                               = weapons\detector\detector_8_draw
+snd_holster                                            = weapons\detector\detector_8_holster
+
+class                                                 = D_CUSTOM
+custom_ui_pos                                         = -0.0242,0.02947,-0.0219
+custom_ui_rot                                         = 0,90,0
+custom_ui_func										   = tasks_measure.get_UI
+;custom_ui_bone										   = cover
+
+[detector_anomaly_hud]:detector_simple_hud
+hud_ui_xml_tag_name                                    = test
+hud_ui_attach_bone                                     = wpn_body
+hud_ui_pos                                             = -0.02, 0.06, 0.02
+hud_ui_rot                                             = 0, 120, 0
+hud_ui_size                                            = 0.0576, 0.029
+item_visual                                            = dynamics\devices\dev_detector_8\dev_detector_8_hud
+flash_light_range                                      = 0.0
+onoff_light_range                                      = 0.0
+
+;;--======< Radio receiver >======--
+[detector_radio]:tch_detector
+visual                              	               = dynamics\devices\dev_detector_09\dev_detector_09.ogf
+hud                                                    = detector_radio_hud
+animation_slot                                         = 7
+inv_name                                               = st_detector9
+inv_name_short                                         = st_detector9
+description                                            = st_detector9_descr
+inv_weight                                             = 0.37
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 9
+inv_grid_y                                             = 28
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 150
+upgr_icon_y								 	           = 200
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost                                                   = 2700
+default_to_ruck                                        = true
+snd_draw                                               = weapons\detector\detector_8_draw
+snd_holster                                            = weapons\detector\detector_8_holster
+
+class                                                 = D_CUSTOM
+custom_ui_pos                                         = -0.0228,0.0225,0.0415
+custom_ui_rot                                         = 0,88.5,0
+custom_ui_func										   = item_radio.get_UI
+;custom_ui_bone										   = cover
+
+
+[detector_radio_hud]:detector_simple_hud
+item_visual                                            = dynamics\devices\dev_detector_09\dev_detector_09_hud
+flash_light_range                                      = 0.0
+onoff_light_range                                      = 0.0
+
+;;--======< Geiger Counter >======--
+[detector_geiger]:tch_detector
+GroupControlSection                                    = spawn_group
+$spawn                                                 = "devices\dosimeter"
+$prefetch                                              = 32
+class                                                  = D_CUSTOM
+cform                                                  = skeleton
+visual                                                 = dynamics\devices\dev_dosimeter\dosimeter.ogf
+hud                                                    = detector_geiger_hud
+animation_slot                                         = 7
+inv_name                                               = st_geiger_dead
+inv_name_short                                         = st_geiger_dead
+description                                            = st_geiger_dead_descr
+slot                                                   = 8
+ef_detector_type                                       = 1
+inv_weight                                             = 0.37
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x                                             = 13
+inv_grid_y                                             = 27
+inv_weight			                                   = 0.25
+cost                                                   = 2700
+upgr_icon_path			                               = ui\actor_items\ui_actor_items_1
+upgr_icon_x				                               = 150
+upgr_icon_y				                               = 100
+upgr_icon_width			                               = 150
+upgr_icon_height		                               = 100
+default_to_ruck                                        = true
+attach_angle_offset                                    = -1.303,-1.493,-1.202
+attach_position_offset                                 = 0.110,-0.019,0.000
+attach_bone_name                                       = bip01_l_hand
+snd_draw                                               = weapons\detector\detector_8_draw
+snd_holster                                            = weapons\detector\detector_8_holster
+custom_ui_pos                                          = -0.0281,-0.0101,0.0375
+custom_ui_rot                                          = 0,63,0
+custom_ui_func										   = ui_dosimeter.get_UI
+custom_ui_bone										   = cover
+
+[detector_geiger_hud]:detector_simple_hud
+attach_place_idx                                       = 1
+
+item_position                                          = -0.075000,0.036188,-0.015934
+item_orientation                                       = 325.589233,-190.420761,-185.323669
+item_visual                                            = dynamics\devices\dev_dosimeter\dosimeter_hud
+
+anm_show					                           = d1_draw, draw_dos
+anm_show_fast				                           = d1_draw, draw_dos, 1.5
+anm_hide					                           = d1_holster, holster_dos
+anm_hide_fast				                           = d1_holster, holster_dos, 1.5
+anm_idle					                           = d1_idle, idle
+anm_idle_moving				                           = d1_move, move
+anm_idle_moving_crouch		                           = d1_crouch, move, 0.8
+anm_idle_sprint				                           = d1_sprint, sprint
+
+anm_idle_zoom										   = d1_zoom, idle
+anm_zoom							         	       = d1_zoom_in, idle
+anm_zoom_show							               = d1_zoom_draw, idle, 1.5
+anm_zoom_hide							               = d1_zoom_holster, idle, 1.5
+anm_zoom_hide_fast						               = d1_zoom_holster, idle, 2
+
+anm_throw_start										   = d1_throw_start, idle
+anm_throw											   = d1_throw_idle, idle
+anm_throw_end										   = d1_throw_end, idle
+
+;;--==========================< Flashlight >=============================
+[device_flashlight]:tch_detector
+class                                                  = D_FLALIT
+cform                                                  = skeleton
+visual                                                 = dynamics\devices\dev_flashlight\dev_flashlight.ogf	;dynamics\devices\dev_tactical_torch\dev_tactical_torch.ogf
+hud                                                    = device_flashlight_hud
+slot                                                   = 8
+animation_slot                                         = 7
+cost                                                   = 2440
+inv_weight                                             = 0.484
+inv_grid_width                                         = 1
+inv_grid_height                                        = 1
+inv_grid_x			                                   = 7
+inv_grid_y			                                   = 27
+description			                                   = st_device_flashlight_descr
+inv_name			                                   = st_device_flashlight
+inv_name_short		                                   = st_device_flashlight
+
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 0
+upgr_icon_y								 	           = 100
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+
+attach_angle_offset                                    = -1.303,0.107,-1.702
+attach_position_offset                                 = 0.14,0.001,0.02
+attach_bone_name                                       = bip01_l_hand
+auto_attach                                            = false
+
+torch_offset                                           = 0,0,0
+omni_offset                                            = 0,0,0
+torch_inertion_speed_min                               = 0.5
+torch_inertion_speed_max                               = 7.5
+light_section                                          = flashlight_definition
+light_trace_bone                                       = light_bone_1
+
+attach_angle_offset                                    = 3.062, 0.008, -1.532
+attach_position_offset                                 = 0.134, -0.007, 0.09
+
+[device_flashlight_hud]:detector_base_hud
+
+item_position 							               = -0.053, 0.027, 0.015
+item_orientation 						               = -8, -11.5,50
+
+hands_position			                               = 0.07, -0.21, -0.22
+hands_orientation		                               = 3, 6, 0
+hands_position_16x9		                               = 0.07, -0.21, -0.22
+hands_orientation_16x9	                               = 3, 6, 0
+
+aim_hud_offset_pos         							   = -0.15, 0.045, -0.04
+aim_hud_offset_pos_16x9								   = -0.15, 0.045, -0.04
+aim_hud_offset_rot        							   = 0.05, 0.09, -0.015
+aim_hud_offset_rot_16x9								   = 0.05, 0.09, -0.015
+
+item_visual                                            = dynamics\devices\dev_tactical_torch\dev_tactical_torch_hud
+fire_point                                             = 0,0,-0.25
+fire_direction							               = 0,0,1			;Note: engine default is 0,0,1
+fire_bone                                              = light_bone_2
+fire_point2                                            = 0,0,0
+fire_bone2                                             = wpn_body
+
+anm_show                                               = tactical_torch_draw, idle_tactical_torch
+anm_show_fast                                          = tactical_torch_draw, idle_tactical_torch, 1.25
+anm_hide                                               = tactical_torch_holster, idle_tactical_torch
+anm_hide_fast                                          = tactical_torch_holster_fast, idle_tactical_torch, 1.25
+anm_idle                                               = tactical_torch_idle, idle_tactical_torch
+anm_idle_moving                                        = tactical_torch_moving, idle_tactical_torch
+anm_idle_sprint                                        = tactical_torch_sprint, idle_tactical_torch
+anm_idle_zoom							 	           = tactical_torch_zoom, idle_tactical_torch
+anm_zoom								               = tactical_torch_zoom_in, idle_tactical_torch
+anm_zoom_show							               = tactical_torch_zoom_draw, idle_tactical_torch, 1.5
+anm_zoom_hide							               = tactical_torch_zoom_holster, idle_tactical_torch, 1.5
+anm_zoom_hide_fast						               = tactical_torch_zoom_holster_fast, idle_tactical_torch, 2
+
+anm_throw_start										   = tactical_torch_throw_start, idle_tactical_torch
+anm_throw											   = tactical_torch_throw_idle, idle_tactical_torch
+anm_throw_end										   = tactical_torch_throw_end, idle_tactical_torch
+
+[flashlight_definition]
+type                                                   = 2 ; type  0-Direct 1-Point 2-Spot 3-OMNIPART 4-Reflected
+range                                                  = 20 ; range                 <in meters>
+range_r2                                               = 20 ; range                 <in meters>
+color                                                  = 0.8,0.7,0.8,0.2 ; four color components <r,g,b,a> 0.f<X<3.f
+color_r2                                               = 1.0,0.9,1.0,0.9 ; four color components <r,g,b,a> 0.f<X<3.f
+color_animator                                         = empty ; color animator name   (empty - not using animator) //light_torch_01
+volumetric                                             = false
+volumetric_quality                                     = 0.5
+volumetric_intensity                                   = 0.10
+volumetric_distance                                    = 0.25
+
+omni_type                                              = 1 ; type  0-Direct 1-Point 2-Spot 3-OMNIPART 4-Reflected
+omni_range                                             = 2 ; range                 <in meters>
+omni_range_r2                                          = 0.5 ; range                 <in meters>
+omni_color                                             = 0.35,0.3,0.35,0.1 ; four color components <r,g,b,a> 0.f<X<3.f
+omni_color_r2                                          = 0.45,0.4,0.45,0.1 ; four color components <r,g,b,a> 0.f<X<3.f
+
+spot_texture                                           = internal\internal_tactical_torch ; spot texture name     (using only in Second Render)
+spot_angle                                             = 65 ; spot angle            <in gradus>
+
+glow_texture                                           = glow\glow_tactical_torch ; glow texture name     (required)
+glow_radius                                            = 0.2 ; glow radius           <in meters>
+guide_bone                                             = light_bone_1 ; guid bone name        (required)
+
+;;--==========================< Torch >=============================
+;-- device_torch is a base section, used for npcs too. better use others for player.
+;-- when you add new torches, you should assign their sections in actor.ltx, "attachable_items" parameter. Otherwise they will stick in the place you spawned them at
+;-- Torch keybind is disabled in engine. Torches are controlled by scripts instead for custom torch events.
+
+[device_torch_dummy]:tch_device,device_torch
+inv_name				                               = st_device_torch_name
+inv_name_short			                               = st_device_torch_name
+description				                               = st_device_torch_descr
+cost												   = 4390
+default_to_ruck                          		       = true
+anim_item								 			   = false
+condition_bar									       = power_progess_bar
+tier                                                   = 2
+
+[device_torch_nv_1]:tch_device,device_torch
+inv_name				                               = st_device_torch_nv_1_name
+inv_name_short			                               = st_device_torch_nv_1_name
+description				                               = st_device_torch_nv_1_descr
+icons_texture                                          = ui\ui_icon_bas
+inv_grid_width     = 1
+inv_grid_height    = 1
+inv_grid_x         = 143
+inv_grid_y         = 2
+nv_effect										       = nightvision_1
+cost					                               = 19650
+default_to_ruck                          		       = true
+anim_item								 			   = false
+condition_bar									       = power_progess_bar
+tier                                                   = 3
+
+[device_torch_nv_2]:tch_device,device_torch
+inv_name				                               = st_device_torch_nv_2_name
+inv_name_short			                               = st_device_torch_nv_2_name
+description				                               = st_device_torch_nv_2_descr
+icons_texture                                          = ui\ui_icon_bas
+inv_grid_width     = 1
+inv_grid_height    = 1
+inv_grid_x         = 142
+inv_grid_y         = 2
+nv_effect										       = nightvision_2	;nightvision_bluer
+cost					                               = 24553
+default_to_ruck                          		       = true
+anim_item								 			   = false
+condition_bar									       = power_progess_bar
+tier                                                   = 4
+
+[device_torch_nv_3]:tch_device,device_torch
+inv_name				                               = st_device_torch_nv_3_name
+inv_name_short			                               = st_device_torch_nv_3_name
+description				                               = st_device_torch_nv_3_descr
+icons_texture                                          = ui\ui_icon_bas
+inv_grid_width     = 1
+inv_grid_height    = 1
+inv_grid_x         = 141
+inv_grid_y         = 2
+nv_effect										       = nightvision_3
+cost					                               = 31431
+default_to_ruck                          		       = true
+anim_item								 			   = false
+condition_bar									       = power_progess_bar
+tier                                                   = 5
+
+[torch_definition]
+type											= 2										; type  0-Direct 1-Point 2-Spot 3-OMNIPART 4-Reflected
+range           								= 25									; range                 <in meters>
+range_r2        								= 25			 						; range                 <in meters>
+color           								= 0.8,0.7,0.7,0.2						; four color components <r,g,b,a> 0.f<X<3.f
+color_r2        								= 1.0,0.9,0.9,0.9						; four color components <r,g,b,a> 0.f<X<3.f
+color_animator  								= empty									; color animator name   (empty - not using animator) //light_torch_01
+volumetric						 				= false
+volumetric_for_actor							= false
+volumetric_quality				 				= 1.0
+volumetric_intensity				 			= 1.0
+volumetric_distance				 				= 1.0
+
+omni_type										= 1										; type  0-Direct 1-Point 2-Spot 3-OMNIPART 4-Reflected
+omni_range     									= 1.5									; range                 <in meters>
+omni_range_r2   								= 0.75									; range                 <in meters>
+omni_color      								= 0.4,0.35,0.35,0.1						; four color components <r,g,b,a> 0.f<X<3.f
+omni_color_r2   								= 0.5,0.45,0.45,0.1						; four color components <r,g,b,a> 0.f<X<3.f
+
+spot_texture    								= internal\internal_light_torch_r2		; spot texture name     (using only in Second Render)
+spot_angle      								= 60									; spot angle            <in gradus>
+
+glow_texture    								= glow\glow_torch_r2					; glow texture name     (required)
+glow_radius     								= 0.2									; glow radius           <in meters>
+guide_bone      								= lights_bone							; guid bone name        (required)
+
+;;--==========================< Batteries >=============================
+[batteries_dead]:identity_immunities,tch_device
+$spawn 				                                   = "food and drugs\kolbasa"
+$prefetch 			                                   = 16
+kind								                   = i_tool
+cform				                                   = skeleton
+visual				                                   = dynamics\equipments\trade\battery.ogf
+inv_weight			                                   = 0.127
+inv_name			                                   = st_batteries
+inv_name_short		                                   = st_batteries
+description			                                   = st_batteries_descr
+inv_grid_width		                                   = 1
+inv_grid_height		                                   = 1
+inv_grid_x			                                   = 0
+inv_grid_y			                                   = 26
+upgr_icon_path								           = ui\actor_items\ui_actor_items_1
+upgr_icon_x								 	           = 0
+upgr_icon_y								 	           = 0
+upgr_icon_width						 	 	           = 150
+upgr_icon_height						 	           = 100
+cost				                                   = 624
+attach_angle_offset		                               = 0.440521, 1.378287, -0.644026
+attach_position_offset	                               = 0.104196, -0.010821, 0.076969
+attach_bone_name		                               = bip01_r_hand
+auto_attach				                               = false
+bone_name				                               = bip01_r_hand
+position_offset			                               = 0.0,0.0,0.0
+angle_offset			                               = 1.570790,1.570790,3.92699
+;use_sound			                                   = interface\inv_batt
+tier                                                   = 1
+
+
+;;--==========================< Watch >=============================
+[hand_watch]:booster ;;--(new)
+;class                                                 = II_ANTIR
+kind								           	       = i_misc
+visual                                                 = dynamics\equipments\trade\battery.ogf
+inv_name			                                   = st_hand_watch
+inv_name_short		                                   = st_hand_watch
+description			                                   = st_hand_watch_descr
+inv_weight   	                                       = 0.15
+inv_grid_width		                                   = 1
+inv_grid_height		                                   = 1
+inv_grid_x			                                   = 12
+inv_grid_y			                                   = 27
+cost    		                                       = 3546
+attach_angle_offset		                               = -0.287979, 1.560923, 1.544060
+attach_position_offset		                           = 0.096910, -0.013594, 0.107925
+attach_bone_name		                               = bip01_r_hand
+quest_item                                             = false
+can_trade                                              = true
+remove_after_use                                       = false
+tier                                                   = 3
+
+;;--==========================< Doppler Weather Radar Kit >=============================
+[device_weather_radar]:booster
+class                                                  = II_ANTIR
+kind								           		   = i_device
+visual                                                 = dynamics\equipments\quest\notebook.ogf
+inv_name			                                   = st_weather_radar
+inv_name_short		                                   = st_weather_radar
+description			                                   = st_weather_radar_descr
+inv_weight   	                                       = 4.7
+inv_grid_width		                                   = 2
+inv_grid_height		                                   = 2
+inv_grid_x			                                   = 10
+inv_grid_y			                                   = 10
+cost    		                                       = 34000
+attach_angle_offset		                               = -0.287979, 1.560923, 1.544060
+attach_position_offset		                           = 0.096910, -0.013594, 0.107925
+attach_bone_name		                               = bip01_r_hand
+quest_item                                             = false
+can_trade                                              = false
+remove_after_use                                       = false
+use_sound			                                   = device\pda\pda_welcome
+1icon_layer_x       	                               = 10
+1icon_layer_y      		                               = 160
+1icon_layer_scale   	                               = 0.45
+1icon_layer        	                                   = af_mincer_meat

--- a/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/items/items/items_devices.ltx
+++ b/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/items/items/items_devices.ltx
@@ -789,6 +789,14 @@ zone_class_45										   = zone_mine_point
 zone_class_46										   = zone_mine_radar
 zone_class_47										   = zone_mine_sphere
 
+zone_class_48										   = zone_mine_acid
+zone_class_49										   = zone_mine_electra
+zone_class_50										   = zone_mine_springboard
+zone_class_51										   = zone_mine_vortex
+zone_class_52										   = zone_mine_blast
+zone_class_53										   = zone_mine_zharka
+zone_class_54										   = zone_mine_vapour
+
 zone_freq_1			                                   = 0.05, 2
 zone_freq_2			                                   = 0.05, 2
 zone_freq_3			                                   = 0.05, 2
@@ -836,6 +844,13 @@ zone_freq_44										   = 0.05, 2
 zone_freq_45										   = 0.05, 2
 zone_freq_46										   = 0.05, 2
 zone_freq_47										   = 0.05, 2
+zone_freq_48										   = 0.05, 2
+zone_freq_49										   = 0.05, 2
+zone_freq_50										   = 0.05, 2
+zone_freq_51										   = 0.05, 2
+zone_freq_52										   = 0.05, 2
+zone_freq_53										   = 0.05, 2
+zone_freq_54										   = 0.05, 2
 
 [detector_scientific_hud]:detector_base_hud
 

--- a/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/ui/ui_detector_artefact.xml
+++ b/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/ui/ui_detector_artefact.xml
@@ -185,6 +185,28 @@
       <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
     </palette>
 
+    <palette id="zone_mine_acid" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_electra" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_springboard" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_vortex" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_blast" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_zharka" width="0.006" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_mine_vapour" width="0.006" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+
 <!--
     <palette id="zone_mine_acidic_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
       <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>

--- a/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/ui/ui_detector_artefact.xml
+++ b/G.A.M.M.A/modpack_addons/Wildkins's DAO Svarog Patch/gamedata/configs/ui/ui_detector_artefact.xml
@@ -1,0 +1,687 @@
+<w>
+  <elite x="0" y="0" width="0.0576" height="0.029">
+    <wrk_area width="0.0576" height="0.029">
+      <auto_static width="0.0576" height="0.029" stretch="1">
+        <texture shader="hud\p3d">ui_temp_ad3_radar_glow</texture>
+      </auto_static>
+    </wrk_area>
+
+    <af_sign width="0.0045" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </af_sign>
+
+    <palette id="af_sign" width="0.0045" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+  </elite>
+
+  <scientific x="0" y="0" width="0.0576" height="0.029">
+    <wrk_area width="0.0576" height="0.029">
+      <auto_static width="0.0576" height="0.029" stretch="1">
+        <texture shader="hud\p3d">ui_temp_ad3_radar_glow</texture>
+      </auto_static>
+    </wrk_area>
+
+    <palette id="zone_mine_acidic_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_acidic_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_acidic_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+
+    <palette id="zone_mine_chemical_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_chemical_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_chemical_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+
+    <palette id="zone_buzz_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_buzz_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_buzz_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+<!--
+    <palette id="zone_mine_acidic_big" width="0.03" height="0.03" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+-->
+    <palette id="zone_mine_electric_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_electric_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_electric_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+
+    <palette id="zone_mine_static_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_static_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_static_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+
+    <palette id="zone_witches_galantine_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_witches_galantine_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_witches_galantine_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+
+    <palette id="zone_mine_gravitational_strong" width="0.008" height="0.008" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_gravitational_average" width="0.008" height="0.008" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_gravitational_weak" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+<!--
+    <palette id="zone_mine_gravitational_big" width="0.032" height="0.032" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+-->
+    <palette id="zone_gravi_zone" width="0.008" height="0.008" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+
+    <palette id="zone_mine_thermal_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_mine_thermal_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_mine_thermal_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+
+    <palette id="zone_zharka_static_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_zharka_static_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_zharka_static_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+
+    <palette id="zone_mine_steam_strong" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_mine_steam_average" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+    <palette id="zone_mine_steam_weak" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_fire_big</texture>
+    </palette>
+
+	
+	  <palette id="zone_mosquito_bald" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mosquito_bald_weak" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mosquito_bald_weak_noart" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mosquito_bald_average" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mosquito_bald_strong" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mosquito_bald_strong_noart" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+
+    <palette id="zone_mine_darkness" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_flash" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_ghost" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_gold" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_green_dragon" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_acid_big</texture>
+    </palette>
+    <palette id="zone_mine_mefistotel" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_net" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+    <palette id="zone_mine_point" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_radar" width="0.006" height="0.006" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_electro_big</texture>
+    </palette>
+    <palette id="zone_mine_sphere" width="0.008" height="0.008" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_gravity_big</texture>
+    </palette>
+
+<!--
+    <palette id="zone_mine_acidic_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_mine_acidic_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_mine_acidic_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+
+    <palette id="zone_mine_chemical_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_mine_chemical_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_mine_chemical_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+
+    <palette id="zone_buzz_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_buzz_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+    <palette id="zone_buzz_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+
+    <palette id="zone_mine_acidic_big" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_acidic</texture>
+    </palette>
+
+    <palette id="zone_mine_electric_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_mine_electric_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_mine_electric_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+
+    <palette id="zone_mine_static_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_mine_static_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_mine_static_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+
+    <palette id="zone_witches_galantine_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_witches_galantine_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+    <palette id="zone_witches_galantine_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_electric</texture>
+    </palette>
+
+    <palette id="zone_mine_gravitational_strong" width="0.013" height="0.013" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_gravitational</texture>
+    </palette>
+    <palette id="zone_mine_gravitational_average" width="0.013" height="0.013" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_gravitational</texture>
+    </palette>
+    <palette id="zone_mine_gravitational_weak" width="0.01" height="0.01" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_gravitational</texture>
+    </palette>
+
+    <palette id="zone_mine_gravitational_big" width="0.013" height="0.013" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_gravitational</texture>
+    </palette>
+
+    <palette id="zone_gravi_zone" width="0.013" height="0.013" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_gravitational</texture>
+    </palette>
+
+    <palette id="zone_mine_thermal_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_mine_thermal_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_mine_thermal_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+
+    <palette id="zone_zharka_static_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_zharka_static_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_zharka_static_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+
+    <palette id="zone_mine_steam_strong" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_mine_steam_average" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+    <palette id="zone_mine_steam_weak" width="0.0065" height="0.0065" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad4_mine_thermal</texture>
+    </palette>
+
+    <palette id="af_blood" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_mincer_meat" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_soul" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_fuzz_kolobok" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_baloon" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_glass" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+
+    <palette id="af_electra_sparkler" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_electra_flash" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_electra_moonlight" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_dummy_battery" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_dummy_dummy" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_ice" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+
+    <palette id="af_medusa" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_cristall_flower" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_night_star" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_vyvert" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_gravi" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_gold_fish" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+
+    <palette id="af_cristall" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_fireball" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_dummy_glassbeads" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_eye" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_fire" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+
+    <palette id="af_oasis_heart" width="0.004" height="0.004" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="af_quest_b14_twisted" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+    <palette id="jup_b1_half_artifact" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_temp_ad3_artefact</texture>
+    </palette>
+-->
+
+    <palette id="af_blood" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_mincer_meat" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_soul" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_fuzz_kolobok" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_baloon" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_glass" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+    <palette id="af_electra_sparkler" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_electra_flash" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_electra_moonlight" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_dummy_battery" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_dummy_dummy" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_ice" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+    <palette id="af_medusa" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_cristall_flower" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_night_star" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_vyvert" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_gravi" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_gold_fish" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+    <palette id="af_cristall" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_fireball" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_dummy_glassbeads" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_eye" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_fire" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+    <palette id="af_oasis_heart" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="af_quest_b14_twisted" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+    <palette id="jup_b1_half_artifact" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+	<palette id="af_drops" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ameba_slime" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ameba_slug" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ameba_mica" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_dummy_spring" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_dummy_pellicle" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_rusty_thorn" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_rusty_kristall" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_rusty_sea" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_compass" width="0.005" height="0.005" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	
+	<palette id="af_black_spray" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_bracelet" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_death_lamp" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_empty" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_full_empty" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_itcher" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_lobster_eyes" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_pin" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_ring" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_sponge" width="0.005" height="0.005" stretch="1" alignment="c">
+	  <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	
+	<palette id="af_dragon_eye" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_fire_loop" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_ball" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_fonar" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_tapeworm" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_moh" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_serofim" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_elektron" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_kogot" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_generator" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_black_angel" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_grapes" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_skull_miser" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_star_phantom" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_medallion" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_peas" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_kislushka" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_zhelch" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_sandstone" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_fountain" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_spaika" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_signet" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_repei" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_bat" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_sun" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_ear" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_chelust" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_atom" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_lighthouse" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_cell" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_cocoon" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	
+	<palette id="af_black" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_gimlet" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_geliy" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_vaselisk" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+	<palette id="af_monolith" width="0.005" height="0.005" stretch="1" alignment="c">
+		<texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+	</palette>
+
+        <palette id="af_ah_o1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_o2" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>	
+	<palette id="af_ah_e1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_e2" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_g1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_g2" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_h1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_h2" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_s1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_f1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_r1" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_r2" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_r3" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+	<palette id="af_ah_r4" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>		
+	<palette id="af_ah_r5" width="0.003" height="0.003" stretch="1" alignment="c">
+      <texture shader="hud\p3d">ui_inGame2_Detector_icon_artefact</texture>
+    </palette>
+
+  </scientific>
+</w>


### PR DESCRIPTION
Title

adds zone_class / zone_freq definitions for the new anomalies under the Svarog detector in `items_devices.ltx`, and icons for them under `ui_detector_artefact.xml`

The former file is taken from the EFT Reposition BAS Patch, as Apathy's Better Detector Position is currently disabled; `ui_detector_artefact.xml` is taken from `197 - New Storylines` which is the only mod in the pack to edit that file