### PR TITLE
Comment out RAPTR remove duplicate bm16

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_shotgun_range_balance_Larkin.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_shotgun_range_balance_Larkin.ltx
@@ -37,8 +37,8 @@ fire_distance               = 250
 ![wpn_protecta_aim]
 fire_distance               = 250
 
-![wpn_raptr]
-fire_distance               = 250
+;![wpn_raptr]
+;fire_distance               = 250
 
 ![wpn_remington870]
 fire_distance               = 250
@@ -68,9 +68,6 @@ fire_distance               = 250
 fire_distance               = 250
 
 ![wpn_toz34_obrez]
-fire_distance               = 250
-
-![wpn_toz66]
 fire_distance               = 250
 
 ![wpn_wincheaster1300]


### PR DESCRIPTION
RAPTR comment to remove log error until implemented. Remove TOZ66 as its the BM16 and I accidentally left it in.