### PR TITLE
Warfare fixes and improvements

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Locations/gamedata/configs/plugins/new_game_start_locations.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Locations/gamedata/configs/plugins/new_game_start_locations.ltx
@@ -67,7 +67,7 @@ l13_generators         = l12_stancia,true
 kbo_monolith           = pripyat,true
 
 [isg_start_locations]
-dasc_sawwill           = l01_escape,false
+dasc_sawwill           = l01_escape,true
 
 [renegade_start_locations]
 tuzla_outpost          = k00_marsh,true

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -116,7 +116,7 @@ options = {
 		{ id= "texture_lod"            ,type= "track"    ,val= 2	,cmd= "texture_lod"	                ,min= 0     ,max= 4     ,step= 1 	,no_str= true	  ,invert= true     ,vid= true	,restart= true	},
 		{ id= "geometry_lod"           ,type= "track"    ,val= 2	,cmd= "r__geometry_lod"	            ,min= 0.1   ,max= 1.5   ,step= 0.1 },
 		{ id= "mipbias"           	   ,type= "track"    ,val= 2	,cmd= "r__tf_mipbias"	            ,min= -0.5  ,max= 0.5   ,step= 0.1 	,no_str= true 	  ,invert= true },
-		{ id= "tf_aniso"               ,type= "track"    ,val= 2	,cmd= "r__tf_aniso"	                ,min= 1     ,max= 16    ,step= 4    ,vid= true	},
+		{ id= "tf_aniso"               ,type= "list"     ,val= 0	,cmd= "r__tf_aniso"	                ,content={ {"0","0"},{"4","4"},{"8","8"},{"16","16"} }    ,vid= true, no_str= true	},
 		{ id= "ssample"                ,type= "track"    ,val= 2	,cmd= "r__supersample"	            ,min= 1     ,max= 8     ,step= 1       ,vid= true      ,precondition= {for_renderer,"renderer_r1","renderer_r2a","renderer_r2","renderer_r2.5"} },
 		{ id= "ssample_list"           ,type= "list"     ,val= 0	,cmd= "r3_msaa"	                    ,content={ {"st_opt_off","st_opt_off"},{"2x","x2"},{"4x","x4"},{"8x","x8"} }	    ,vid= true          ,precondition= {for_renderer,"renderer_r3","renderer_r4"} , no_str= true  },
 		{ id= "smaa"           		   ,type= "list"     ,val= 0	,cmd= "r2_smaa"	                    ,content={ {"off","st_opt_off"},{"low","st_opt_low"},{"medium","st_opt_medium"},{"high","st_opt_high"},{"ultra","st_opt_ultra"} } ,precondition= {for_renderer,"renderer_r2a","renderer_r2","renderer_r2.5","renderer_r3","renderer_r4"}, no_str= true  },

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/configs/misc/simulation_objects_props.ltx
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/configs/misc/simulation_objects_props.ltx
@@ -1,0 +1,2689 @@
+;-- NOTE: make sure all smarts here inhirit one of the base sections, they should have all properties
+
+[default]
+base 			        = 0
+territory		        = 0
+resource 		        = 0
+surge			        = 0
+lair			        = 0
+actor			        = 0
+squad 			        = 0
+
+bandit 			        = 0
+dolg			        = 0
+ecolog			        = 0
+freedom			        = 0
+killer			        = 0
+army 			        = 0
+monolith		        = 0
+stalker 		        = 0
+csky			        = 0
+zombied			        = 0
+
+greh					= 0
+isg						= 0
+renegade                = 0
+
+greh_npc				= 0
+army_npc				= 0
+
+
+zoo_monster				= 0
+monster					= 0
+monster_predatory_day 	= 0
+monster_predatory_night = 0
+monster_vegetarian		= 0
+monster_zombied_day		= 0
+monster_zombied_night	= 0
+monster_special			= 0
+
+army_heli		        = 0
+monolith_heli 	        = 0
+killer_heli		        = 0
+stalker_heli 	        = 0
+bandit_heli 	        = 0
+csky_heli 	            = 0
+freedom_heli 	        = 0
+dolg_heli 	            = 0
+ecolog_heli 	        = 0
+renegade_heli 	        = 0
+greh_heli 	            = 0
+isg_heli 	            = 0
+
+
+all				        = 0
+all_stalker				= 0
+all_monster				= 0
+
+[default_resource]:default
+resource 	            = 1
+;territory	            = 1
+ecolog		            = 1
+stalker 	            = 1 
+csky		            = 1
+
+[default_base]:default
+base 		            = 1
+
+[default_lair]:default
+lair					= 1 
+;territory				= 1
+zoo_monster				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 1
+monster_vegetarian		= 1
+monster_zombied_day		= 1
+monster_zombied_night	= 1
+monster_special			= 1
+
+[weak_lair]:default
+lair					= 1 
+;territory				= 1
+zoo_monster				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 0
+monster_vegetarian		= 1
+monster_zombied_day		= 0
+monster_zombied_night	= 0
+monster_special			= 0
+
+[default_territory]:default
+territory 	            = 1
+all			            = 1
+
+[default_squad]:default
+sim_avail               = false
+squad 		            = 1
+all 		            = 1
+
+[actor]:default
+sim_avail 	            = true
+actor		            = 1
+all 		            = 1
+
+;----------- << MARSH >> ------------
+;unique starting base
+[mar_smart_terrain_base]:default_base
+sim_avail 	            = true
+ecolog		            = 1
+stalker		            = 1
+surge 		            = 1
+resource		= 1
+csky 		            = 2
+
+[mar_smart_terrain_doc]:default_territory
+sim_avail 	            = false
+
+[mar_smart_terrain_doc_2]:default_territory
+sim_avail 	            = false
+
+;---------	SIMULATION	--------
+;NW fishing village, renegades
+[mar_smart_terrain_3_3]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource				= 1
+bandit 		            = 1
+renegade				= 1
+
+[mar_smart_terrain_3_7]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+csky			        = 1
+ecolog			        = 1
+
+[mar_smart_terrain_3_10]:weak_lair
+sim_avail 	            = true
+
+;NW ruined village, military
+[mar_smart_terrain_4_5]:default_territory
+sim_avail 	            = true
+surge 		            = 1
+bandit 		            = 1
+lair 		            = 1
+stalker 		        = 1
+renegade				= 1
+
+[mar_smart_terrain_4_7]:weak_lair
+sim_avail 	            = true
+bandit 			        = 1
+stalker 		        = 1
+renegade				= 1
+
+;Center, pumping station
+[mar_smart_terrain_5_8]:default_base
+sim_avail 	            = {+pump_station_defense_task_smart_reserved} false, true
+ecolog		            = 1
+stalker		            = 1
+bandit		            = 1
+csky		            = 1
+killer		            = 1
+surge 		            = 1
+resource		= 1
+renegade				= 1
+
+;Southwest, fishing village
+[mar_smart_terrain_5_12]:default_base
+sim_avail 	= {+faction_base_defense_active} false, true
+stalker	                = 1
+bandit		            = 1
+renegade				= 1
+csky		            = 1
+surge 		            = 1
+lair 		            = 1 
+
+
+[mar_smart_terrain_6_4]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_6_7]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_6_8]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_6_10]:weak_lair
+sim_avail 	            = true
+
+;South watchtower
+[mar_smart_terrain_6_11]:default_territory
+sim_avail 	            = true
+lair 		            = 1 
+csky		            = 1
+bandit 		            = 1
+renegade				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 1
+monster_vegetarian		= 1
+
+[mar_smart_terrain_7_3]:default_resource
+sim_avail 	            = true
+bandit 			        = 1
+renegade				= 1
+stalker 		        = 1
+
+[mar_smart_terrain_7_7]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_8_4]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_8_8]:default_resource
+sim_avail 	            = true
+lair 		            = 1 
+bandit 			        = 1
+renegade				= 1
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+freedom			        = 1
+
+[mar_smart_terrain_8_9]:weak_lair
+sim_avail 	            = true
+stalker 		        = 1
+csky			        = 1
+bandit 			        = 1
+renegade				= 1
+
+;East temple
+[mar_smart_terrain_8_11]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+bandit 			        = 1
+renegade				= 1
+stalker 		        = 1
+csky			        = 1
+
+;NE car repair, military
+[mar_smart_terrain_10_5]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+army		            = 1
+army_heli	            = 1
+
+[mar_smart_terrain_10_7]:weak_lair
+sim_avail 	            = true
+
+[mar_smart_terrain_10_10]:default_resource
+sim_avail 	            = true
+lair 		            = 1 
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+
+[mar_smart_terrain_11_3]:weak_lair
+sim_avail 	            = true
+lair 		            = 1 
+
+;SE village, exit1 to Escape
+[mar_smart_terrain_11_11]:default_base
+sim_avail 	            = true
+surge 		            = 1
+stalker		            = 1
+bandit		            = 1 
+renegade				= 1
+csky 		            = 1
+ecolog		            = 1 
+killer		            = 1
+freedom		            = 1
+dolg		            = 1
+
+;NE village, exit2 to Escape
+[mar_smart_terrain_12_2]:default_base
+sim_avail 	            = true
+resource	       = 1
+surge 		            = 1
+stalker 		        = 1
+bandit 			        = 1
+renegade				= 1
+csky 		            = 1
+ecolog		            = 1 
+
+;--------- <<  ESCAPE >> ----------------
+;---------	SIMULATION	--------
+;sim smarties
+;novice camp
+[esc_smart_terrain_2_12]:default_base
+sim_avail 	            = true 
+surge		            = 1
+stalker		            = 1 
+csky		            = 1
+ecolog		            = 1
+monolith				= 0
+army					= 0
+killer					= 0
+lair                    = 1
+
+;military base
+[esc_smart_terrain_3_16]:default_base
+sim_avail 	            = true
+surge		            = 1
+resource		= 1
+army_heli	            = 1
+army 			        = 1
+
+;car repair
+[esc_smart_terrain_7_11]:default_base
+sim_avail 	            = true
+surge		            = 1 
+bandit 		            = 1
+
+;туннель
+[esc_smart_terrain_4_9]:default_lair
+sim_avail 	            = true
+surge 		            = 1 
+bandit 			        = 1
+stalker 		        = 1
+
+;cordon-garbage building
+[esc_smart_terrain_5_2]:default_base
+sim_avail 	            = true
+surge 		            = 1
+army_heli	            = 1
+army 		            = 1
+stalker 		        = 1
+bandit 			        = 1
+
+;Stalker farmhouse
+[esc_smart_terrain_5_7]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource			= 1
+stalker 		        = 1
+csky			        = 1
+
+;mill
+[esc_smart_terrain_5_9]:default_base
+sim_avail 	            = true
+surge 		            = 1
+bandit 		            = 1
+freedom		            = 1
+killer		            = 1
+
+;fox house
+[esc_smart_terrain_6_6]:default_base
+sim_avail 	            = true
+surge 		            = 1
+bandit 			        = 1
+stalker 		        = 1
+
+[esc_smart_terrain_1_11]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+csky			        = 1
+ecolog			        = 1
+
+[esc_smart_terrain_2_14]:weak_lair
+sim_avail 	            = true
+
+[esc_smart_terrain_3_7]:weak_lair
+sim_avail 	            = true
+csky			        = 1
+stalker 		        = 1
+bandit  		        = 1
+
+[esc_smart_terrain_4_11]:default_territory
+sim_avail 	            = true
+stalker 		        = 1
+monster					= 1
+monster_vegetarian		= 1
+
+[esc_smart_terrain_4_13]:weak_lair
+sim_avail 	            = true
+
+[esc_smart_terrain_5_12]:weak_lair
+sim_avail 	            = true
+stalker 		        = 1
+
+
+[esc_smart_terrain_5_4]:default_resource ; weak_lair
+sim_avail 	            = true
+bandit    	            = 1
+
+[esc_smart_terrain_5_6]:weak_lair
+sim_avail 	            = true
+bandit    	            = 1
+
+;ruined rail bridge
+[esc_smart_terrain_6_8]:default_territory
+sim_avail 	            = true
+surge 		            = 1
+all 		            = 0
+army 		            = 1
+bandit		            = 1
+
+[esc_smart_terrain_8_10]:default_lair
+sim_avail 	            = true
+bandit    	            = 1
+
+[esc_smart_terrain_8_9]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+
+[esc_smart_terrain_9_7]:default_lair
+sim_avail 	            = true
+bandit    	            = 1
+
+[esc_smart_terrain_9_10]:weak_lair
+sim_avail 	            = true
+
+
+;----------- << GARBAGE >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+
+;exit to Agroprom1
+[gar_smart_terrain_1_5]:weak_lair
+sim_avail 	            = true
+surge 		            = 1
+bandit 			        = 1
+
+;exit to Agroprom2
+[gar_smart_terrain_1_7]:weak_lair
+sim_avail 	            = true
+bandit 			        = 1
+dolg			        = 1
+stalker 		        = 1
+
+;camp near tunnel
+[gar_smart_terrain_2_4]:default_resource
+sim_avail 	            = true
+surge 		            = 1
+bandit 	                = 1
+
+;hangar
+[gar_smart_terrain_3_5]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+resource		= 1
+stalker		            = 1
+dolg      	            = 1
+csky                    = 1
+
+[gar_smart_terrain_3_7]:default_resource
+sim_avail 	            = true
+stalker 	            = 1
+ecolog		            = 1
+
+[gar_smart_terrain_4_2]:default_lair
+sim_avail 	            = true
+stalker 		        = 1
+
+[gar_smart_terrain_4_5]:weak_lair
+sim_avail 	            = true
+bandit 			        = 1
+
+;outpost to Bar
+[gar_smart_terrain_5_2]:default_base
+sim_avail 	            = true
+surge		            = 2
+stalker		            = 1
+dolg		            = 2
+freedom		            = 1
+csky		            = 1
+killer		            = 2
+bandit		            = 2
+;monolith 	            = 1
+
+[gar_smart_terrain_5_4]:weak_lair
+sim_avail 	            = true
+
+[gar_smart_terrain_5_5]:weak_lair
+sim_avail 	            = true
+stalker 		        = 1
+
+[gar_smart_terrain_5_6]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+bandit 			        = 1
+ecolog			        = 1
+
+[gar_smart_terrain_5_8]:weak_lair		;created by tronex, test
+sim_avail 	            = true
+stalker 		        = 1
+bandit 			        = 1
+
+[gar_smart_terrain_6_1]:weak_lair
+sim_avail 	            = true
+
+;ruined building
+[gar_smart_terrain_6_3]:default_territory
+sim_avail 	            = true
+surge 		            = 1
+stalker 		        = 1
+csky			        = 1
+
+[gar_smart_terrain_6_6]:default_lair
+sim_avail 	            = true
+
+[gar_smart_terrain_6_7]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+
+[gar_smart_terrain_7_4]:default_lair
+sim_avail 	            = true
+;stalker 		        = 1
+
+[gar_smart_terrain_8_3]:default_resource		;created by tronex, test
+sim_avail 	            = true
+bandit 			        = 1
+dolg			        = 1
+
+[gar_smart_terrain_8_5]:default_lair
+sim_avail 	            = true
+
+;----------- << DARKSCAPE >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+;farmhouse
+[ds2_domik_st]:default_base
+sim_avail 	            = {+lttz_hb_spawned_ds_isg_leader_squad -lttz_hb_removed_ds_isg_leader_squad} false, true
+surge		            = 1
+stalker 	            = 1 
+csky		            = 1 
+bandit 		            = 1
+renegade				= 1
+dolg 		            = 1 
+killer 		            = 1
+
+;camp under rocks
+[ds2_lager_st]:default_territory
+sim_avail 	            = true
+surge		            = 1
+bandit		            = 1
+renegade				= 1
+freedom		            = 1
+stalker 		        = 1
+killer			        = 1
+dolg			        = 1
+
+[ds2_st_dogs]:default_lair
+sim_avail 	            = true
+
+[ds2_st_hoofs]:weak_lair
+sim_avail 	            = true
+
+[ds_boars_nest]:weak_lair
+sim_avail 	            = true
+
+[ds_deb1]:weak_lair
+sim_avail 	            = true
+surge                   = 1
+
+[ds_grverfer2]:weak_lair
+sim_avail 	            = true
+surge                   = 1
+stalker 		        = 1
+
+
+[ds_kem1]:weak_lair
+sim_avail 	            = true
+surge                   = 1
+
+;fuel station
+[ds_kem2]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+;;army		            = 1 
+army_heli	            = 1
+
+[ds_kem3]:default_resource
+sim_avail 	            = true
+surge                   = 1
+killer			        = 1
+bandit 			        = 1
+renegade				= 1
+stalker 		        = 1
+
+[ds_ptr]:default_resource
+sim_avail 	            = true
+surge                   = 1
+bandit 			        = 1
+renegade				= 1
+killer			        = 2
+stalker 		        = 1
+
+[ds_ptr2]:weak_lair
+sim_avail 	            = true
+surge                   = 1
+
+[ds_ptr3]:weak_lair
+sim_avail 	            = true
+surge                   = 1
+
+[ds_ptr4]:default_resource
+sim_avail 	            = true
+surge                   = 1
+
+
+;---------	SIMULATION	--------
+;sim smarties
+;exit to Yantar
+[agr_smart_terrain_1_2]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+
+[agr_smart_terrain_1_3]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+freedom			        = 1
+
+;bigger base, courtyard
+[agr_smart_terrain_1_6]:default_base
+sim_avail 	            = true 
+surge		            = 1
+army		            = 1 
+lair 		            = 1 
+
+;bigger base, gate
+[agr_smart_terrain_1_6_near_1]:default_base
+sim_avail 	            = true
+surge		            = 1
+army		            = 1
+
+;bigger base, inside building
+[agr_smart_terrain_1_6_near_2]:default_base
+sim_avail 	            = true
+surge 		            = 1
+army		            = 1
+army_heli	            = 1
+
+[agr_smart_terrain_2_2]:default_lair
+sim_avail 	            = true
+dolg			        = 1
+stalker 		        = 1
+csky			        = 1
+killer			        = 1
+
+;smaller base, inside building
+[agr_smart_terrain_4_4]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+stalker		            = 2 
+csky		            = 1 
+ecolog		            = 1
+
+;smaller base, courtyard
+[agr_smart_terrain_4_4_near_1]:default_base
+sim_avail 	            = true
+surge		            = 1
+stalker		            = 1 
+csky		            = 1 
+ecolog		            = 1
+bandit 		            = 1
+freedom		            = 1
+
+;smaller base, hole in the fence
+[agr_smart_terrain_4_4_near_2]:default_base
+sim_avail 	            = true
+surge                   = 1
+stalker		            = 1 
+csky		            = 1 
+ecolog		            = 1
+
+;smaller base, gate
+[agr_smart_terrain_4_4_near_3]:default_base
+sim_avail 	            = true
+surge                   = 1
+stalker		            = 1 
+csky		            = 1 
+ecolog		            = 1
+bandit		            = 1
+freedom		            = 1
+
+[agr_smart_terrain_4_6]:default_lair
+sim_avail 	            = true
+army		            = 1
+
+;NE campsite by rocks
+[agr_smart_terrain_5_2]:default_lair
+sim_avail 	            = true
+dolg			        = 1
+stalker 		        = 1
+
+;railcar camp near tunnel
+[agr_smart_terrain_5_3]:default_resource
+sim_avail 	            = true
+
+[agr_smart_terrain_5_4]:default_territory		;Created by Tronex, test
+sim_avail 	            = true
+
+[agr_smart_terrain_5_7]:default_resource
+sim_avail 	            = true
+csky			        = 1
+dolg			        = 1
+stalker 		        = 1
+
+;tunnel
+[agr_smart_terrain_6_4]:default_territory
+sim_avail 	            = true 
+surge		            = 1
+stalker		            = 1 
+ecolog		            = 1 
+csky		            = 1
+zombied                 = 1
+
+;Makeshift camp, SE level changer
+[agr_smart_terrain_6_6]:default_resource		;Created by Tronex, test
+sim_avail 	            = true
+
+; camp at level changer to garbage
+; TODO disable/replace bugged jobs
+[agr_smart_terrain_7_4]:default_lair
+sim_avail 				= false
+stalker					= 1 
+army					= 1 
+bandit					= 1 
+
+;dangerous camp on east hill
+[agr_smart_terrain_7_5]:default_lair
+sim_avail 	            = true
+army		            = 1
+dolg			        = 1
+stalker 		        = 1
+csky			        = 1
+bandit 			        = 1
+
+
+;---------	AGROPROM UNDERGROUND SMART TERRAINS	--------
+[agr_u_bandits]:default_territory
+sim_avail               = {+agr_u_bandits_dead} true, false
+lair 		            = 1 
+stalker		            = 1
+;army		            = 1
+bandit		            = 1
+
+[agr_u_bloodsucker]:default_lair
+sim_avail               = {+agru_add_reward} true, false
+
+[agr_u_bloodsucker_2]:default_lair
+sim_avail               = {+agru_add_reward_1} true, false
+territory 	            = 1
+stalker		            = 1
+;army		            = 1
+
+[agr_u_monsters]:default_lair
+sim_avail               = {+agru_controller_death} true, false
+
+[agr_u_soldiers]:default_territory
+sim_avail               = {+agr_u_soldiers_dead +agru_end_poltergeist_squad_dead} true, false
+
+
+;----------- << DARK VALLEY >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+;smaller base, x18 entrance building
+[val_smart_terrain_1_2]:default_base
+sim_avail 	            = true
+surge		            = 1
+resource		= 1
+army		            = 1
+army_heli	            = 1
+
+; camp on hills between farm and central lake
+[val_smart_terrain_3_0]:default_lair
+sim_avail 	            = true
+bandit					= 1
+
+;south pig farm
+[val_smart_terrain_4_0]:default_base
+sim_avail 	            = true
+surge		            = 1
+stalker 	            = 1 
+ecolog		            = 1 
+csky		            = 1
+dolg		            = 1
+killer			        = 1
+freedom			        = 1
+bandit 			        = 1
+renegade				= 1
+
+;camp at northern level changer to to garbage 
+[val_smart_terrain_5_7]:default_lair
+sim_avail 	            = true
+bandit					= 1
+
+;camp at southern level changer to to garbage 
+[val_smart_terrain_5_8]:default_lair
+sim_avail 	            = true
+bandit					= 1
+
+;lair near level changer to meadow
+[val_smart_terrain_5_10]:weak_lair
+sim_avail 	            = true
+
+;camp in front of west exit of bandit base
+[val_smart_terrain_6_4]:weak_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+bandit					= 1
+
+; cliff south of andit base
+[val_smart_terrain_6_5]:default_lair
+sim_avail 	            = true
+
+;bigger base, SOC bandits, CS freedom, inside outer building
+[val_smart_terrain_7_3]:default_base
+sim_avail 	            = true
+surge		            = 1
+resource		= 1
+bandit		            = 2
+
+;bigger base, SOC bandits, CS freedom, inside central building
+[val_smart_terrain_7_4]:default_base
+sim_avail 	            = true
+surge		            = 1
+bandit		            = 1
+lair                    = 1 
+
+;bigger base, SOC bandits, CS freedom, courtyard
+[val_smart_terrain_7_5]:default_base
+sim_avail 	            = true
+surge		            = 1
+resource		= 1
+bandit		            = 1
+
+;north island in lake
+[val_smart_terrain_7_8]:default_lair
+sim_avail 	            = true
+
+;camp near level changer to darkscape
+[val_smart_terrain_7_11]:default_territory
+sim_avail 	            = true
+bandit					= 1
+
+[val_smart_terrain_8_6]:default_territory
+sim_avail 	            = true
+bandit		            = 1
+stalker 	            = 1 
+killer 		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+zoo_monster				= 0
+monster					= 0
+monster_predatory_day 	= 0
+monster_predatory_night = 0
+monster_vegetarian		= 0
+monster_zombied_day		= 0
+monster_zombied_night	= 0
+monster_special			= 0
+
+[val_smart_terrain_8_7]:weak_lair
+sim_avail 	            = true
+
+;south island in lake
+[val_smart_terrain_8_9]:default_lair
+sim_avail 	            = true
+
+[val_smart_terrain_9_10]:default_resource
+sim_avail 	            = true
+stalker 		        = 1
+csky			        = 1
+
+[val_smart_terrain_9_2]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+
+[val_smart_terrain_9_4]:default_base
+sim_avail 	            = true 
+surge		            = 1
+resource		= 1
+bandit		            = 1
+stalker 	            = 1 
+killer 		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+zoo_monster				= 0
+monster					= 0
+monster_predatory_day 	= 0
+monster_predatory_night = 0
+monster_vegetarian		= 0
+monster_zombied_day		= 0
+monster_zombied_night	= 0
+monster_special			= 0
+
+;camp near x-18 building
+[val_smart_terrain_9_6]:default_lair
+sim_avail 	            = true
+surge		            = 1
+bandit		            = 1
+stalker 	            = 1 
+killer 		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+
+;---------	LAB X-18 SMART TERRAINS	--------
+[dar_angar]:default_lair
+sim_avail               = {+dar_military_scout_squad_killed} true, false
+army		            = 1
+ecolog		            = 1
+stalker 	            = 1 
+territory 	            = 1
+
+[dar_control_poltergeist]:default_lair
+sim_avail               = {+dar_military_scout_squad_killed} true, false
+
+[dar_military_scout]:default_territory
+sim_avail               = false
+
+[dar_poltergeist_ring]:default_lair
+sim_avail               = false
+
+[dar_poltergeist_tele]:default_lair
+sim_avail               = false
+
+[dar_poltergeist_tele_round]:default_lair
+sim_avail               = false
+
+[dar_smart_snork]:default_lair
+sim_avail               = {+dar_military_scout_squad_killed} true, false
+;army		            = 1
+ecolog		            = 1
+stalker 	            = 1 
+territory 	            = 1
+
+
+;----------- << BAR >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+[bar_zastava_dogs_lair]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+territory	            = 0
+dolg		            = 1
+stalker		            = 1
+
+[bar_zastava_dogs_lair_2]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+territory	            = 0
+dolg		            = 1
+stalker		            = 1
+
+[bar_dolg_bunker]:default_base
+sim_avail 	            = true
+surge 		            = 1
+dolg		            = 1
+
+[bar_dolg_general]:default_base
+sim_avail 	            = true
+surge 		            = 1
+dolg		            = 1
+
+[bar_visitors]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+stalker		            = 1
+csky		            = 1 
+ecolog		            = 1 
+dolg		            = 1
+
+;unique smarties, sim after guards die
+[bar_zastava]:default_base
+sim_avail               = {!squad_exist(bar_duty_security_squad_leader_squad)} true, false
+surge                   = 1
+dolg                    = 1
+lair                    = 1
+
+[bar_zastava_2]:default_base
+sim_avail               = {!squad_exist(bar_zastava_2_commander_squad)} true, false
+surge                   = 1
+dolg                    = 1
+lair                    = 1
+
+;----------- << ROSTOK (WILD TERRITORY) >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+[ros_smart_killers1]:default_base
+sim_avail 	            = true
+surge 		            = 1
+killer		            = 2
+stalker 		        = 1
+bandit 			        = 1
+dolg			        = 2
+
+[ros_smart_monster4]:default_resource
+sim_avail 	            = true
+territory	            = 0
+lair			        = 1
+ecolog			        = 1
+stalker 		        = 1
+
+[ros_smart_monster5]:default_resource
+sim_avail 	            = true
+territory	            = 0
+stalker 		        = 1
+dolg			        = 1
+lair	 		        = 1
+ecolog			        = 1
+
+[ros_smart_monster7]:default_resource		;edited so rare monsters don't come here
+sim_avail 	            = true
+territory	            = 1  
+ecolog			        = 1
+stalker 		        = 1
+
+[ros_smart_poltergeist2]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[ros_smart_snork1]:default_lair
+sim_avail 	            = true
+territory	            = 0
+dolg			        = 1
+stalker 		        = 1
+
+[ros_smart_stalker_killers1]:default_base
+sim_avail 	            = true
+surge 		            = 1
+killer		            = 1
+
+[ros_smart_stalker1]:weak_lair ; default_territory
+sim_avail 	            = true
+stalker		            = 1 
+ecolog		            = 1 
+csky		            = 1
+dolg		            = 1
+
+;----------- << YANTAR >> ------------
+;---------	SIMULATION	--------
+;sim smarties
+[yan_smart_terrain_1_6]:default_resource
+sim_avail 	            = true
+lair	 		        = 1
+ecolog			        = 1
+stalker 		        = 1
+freedom			        = 1
+zombied			        = 1
+
+;x-16 entrance yard, building
+[yan_smart_terrain_2_4]:default_territory
+sim_avail 	            = true
+lair		            = 1  
+surge		            = 1
+
+;x-16 entrance yard, gate
+[yan_smart_terrain_2_5]:default_resource
+sim_avail 	            = true
+surge		            = 1
+ecolog			        = 1
+stalker 		        = 1
+freedom			        = 1
+
+;x-16 entrance yard
+[yan_smart_terrain_3_4]:default_resource
+sim_avail 	            = true
+surge		            = 1
+
+;camp 2 near small tunnel
+[yan_smart_terrain_3_6]:default_territory
+sim_avail 	            = true
+surge 		            = 1
+lair					= 1
+stalker		            = 1
+ecolog		            = 1 
+csky		            = 1
+
+[yan_smart_terrain_4_2]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+freedom			        = 1
+lair	 		        = 1
+
+[yan_smart_terrain_4_4]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+territory	            = 0
+zombied                 = 1
+
+[yan_smart_terrain_4_5]:default_lair
+sim_avail 	            = true
+
+[yan_smart_terrain_5_3]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+csky			        = 1
+
+;camp near small tunnel
+[yan_smart_terrain_5_5]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+surge		            = 1
+stalker		            = 1 
+ecolog		            = 1 
+csky		            = 1
+zombied                 = 1
+
+[yan_smart_terrain_6_2]:default_lair
+sim_avail 	            = {+faction_base_defense_active} false, true
+territory               = 0
+zombied                 = 1
+csky			        = 1
+
+;scientist base
+[yan_smart_terrain_6_4]:default_base
+sim_avail 	            = true 
+surge		            = 1
+resource		= 1
+stalker		            = 1 
+ecolog		            = 1 
+csky		            = 1
+zombied                 = 1
+
+[yan_smart_terrain_zombi_spawn]:default_territory
+sim_avail 	            = true
+lair		            = 1  
+zombied			        = 1
+
+[yan_smart_terrain_snork_u]:default_lair
+sim_avail               = {+yantar_tunnel_finish} true, false
+
+
+;----------- << LAB X-16 SMARTIES >> ------------
+[x162_st_burer]:default_lair
+sim_avail               = {+yan_kill_brain_done} true, false
+monolith 	            = 1 
+ecolog 		            = 1
+stalker		            = 1
+army 		            = 1
+territory 	            = 1
+
+[x162_st_gigant]:default_lair
+sim_avail               = {+yan_kill_brain_done} true, false
+monolith 	            = 1 
+ecolog 		            = 1
+stalker		            = 1
+army 		            = 1
+territory 	            = 1
+
+[x162_st_snork]:default_lair
+sim_avail               = {+yan_kill_brain_done} true, false
+
+[x162_st_poltergeist]:default_lair
+sim_avail               = {+yan_kill_brain_done} true, false
+
+
+;----------- << ARMY WAREHOUSES >> ------------
+;---------	SIMULATION	--------
+[mil_smart_terrain_2_1]:default_lair
+sim_avail 	            = true
+
+;SOC bloodsuckers village, Freedom camp
+[mil_smart_terrain_2_10]:default_base
+sim_avail 	            = true
+surge		            = 1
+resource		= 1
+freedom		            = 5
+dolg		            = 5
+monolith 	            = 1 
+bandit 		            = 1
+
+;SOC merc outpost to Dead City
+[mil_smart_terrain_2_2]:default_territory
+sim_avail 	            = true
+killer		            = 5
+stalker		            = 1
+bandit		            = 1 
+csky		            = 1
+freedom		            = 1 
+dolg		            = 1 
+monolith	            = 0
+
+;SOC empty farmhouse north
+[mil_smart_terrain_2_4]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource				= 1
+stalker		            = 1
+ecolog		            = 1
+csky		            = 1
+freedom		            = 1
+dolg		            = 2
+killer 		            = 2 
+bandit		            = 1
+renegade				= 1
+
+[mil_smart_terrain_2_6]:default_lair
+sim_avail 	            = true
+monolith	            = 1
+
+;SOC Freedom outpost to Radar, barrier
+[mil_smart_terrain_3_8]:default_base
+sim_avail 	            = true
+resource		= 1
+freedom		            = 5
+dolg 		            = 1
+monolith	            = 2
+
+;SOC bloodsuckers village
+[mil_smart_terrain_4_2]:default_lair
+sim_avail 	            = true
+surge		            = 1
+
+;SOC bloodsuckers village, water tower
+[mil_smart_terrain_4_3]:default_lair ; default_territory
+sim_avail 	            = true
+surge		            = 1
+freedom			        = 2
+stalker 		        = 1
+
+[mil_smart_terrain_4_5]:default_lair
+sim_avail 	            = true
+surge 		            = 1
+stalker		            = 1
+freedom		            = 5
+dolg		            = 2
+bandit		            = 1
+monolith 	            = 1
+
+[mil_smart_terrain_4_7]:default_territory
+sim_avail 	            = {+faction_base_defense_active} false, true
+
+;SOC Freedom outpost to Radar, wagon
+[mil_smart_terrain_4_8]:default_base
+sim_avail 	            = true
+surge 		            = 1
+stalker		            = 1
+freedom		            = 5
+dolg		            = 2
+bandit		            = 1
+monolith 	            = 1
+
+;SOC Freedom base, near kitchen
+[mil_smart_terrain_7_10]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+;stalker	            = 1
+freedom		            = 5
+dolg		            = 0
+;bandit		            = 1
+monolith	            = 0
+
+;SOC Freedom base, near sleep barracks
+[mil_smart_terrain_7_12]:default_base
+sim_avail 	            = true
+surge 		            = 1
+;stalker		        = 1
+freedom		            = 5
+dolg		            = 0
+;bandit		            = 1
+monolith	            = 0
+
+;SOC Duty farm
+[mil_smart_terrain_7_4]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+stalker		            = 1
+freedom		            = 1
+dolg		            = 5
+bandit		            = 1
+monolith 	            = 0
+
+;SOC Freedom base, main
+[mil_smart_terrain_7_7]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+resource				= 1
+;stalker	            = 1
+;csky		            = 1
+freedom		            = 5
+dolg		            = 0
+;bandit		            = 1
+monolith	            = 0
+;lair 		            = 1
+
+;SOC Freedom base, entrance
+[mil_smart_terrain_7_8]:default_base
+sim_avail 	            = true
+surge 		            = 1
+;stalker	            = 1
+;ecolog		            = 1
+;csky		            = 1
+freedom		            = 5
+dolg		            = 0
+;bandit		            = 1
+monolith	            = 0
+
+[mil_smart_terrain_8_3]:default_resource ; weak_lair
+sim_avail 	            = true
+freedom		            = 1
+monolith	            = 0
+
+;----------- << RED FOREST >> ------------
+;---------	SIMULATION	--------
+;Limansk enterance
+[red_bridge_bandit_smart_skirmish]:default_territory ;mlr
+sim_avail 	            = true
+;all			        = 1
+
+;Stancia1 exit camp
+[red_smart_terrain_3_1]:default_territory
+sim_avail 	            = true
+
+;underground mine шахта
+[red_smart_terrain_3_2]:default_base
+sim_avail 	            = true
+;lair                    = 1 
+surge 		            = 1
+resource		= 1
+greh                    = 1
+
+
+[red_smart_terrain_3_3]:default_lair
+sim_avail 	            = true
+
+;Camp near Forester's house - at red forest gate
+[red_smart_terrain_4_2]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+all			            = 1 
+army_heli	            = 1
+
+[red_smart_terrain_4_3]:default_lair
+sim_avail 	            = true
+
+[red_smart_terrain_4_5]:default_lair
+sim_avail 	            = true
+;resource 		        = 2
+
+[red_smart_terrain_5_5]:default_lair
+sim_avail 	            = true
+
+[red_smart_terrain_5_6]:default_lair
+sim_avail 	            = true
+
+;deeper forest - anomaly field with weird rocks
+[red_smart_terrain_6_3]:default_resource
+sim_avail 	            = true
+lair	 		        = 1
+stalker 		        = 1
+ecolog			        = 2
+
+[red_smart_terrain_6_6]:default_lair
+sim_avail 	            = true
+
+;bridge - forest side
+[red_smart_terrain_bridge]:default_base
+sim_avail 	            = true
+surge 		            = 1
+resource		= 1
+all			            = 1
+
+;deeper forest - near T72 tank
+[red_smart_terrain_monsters]:default_resource
+sim_avail 	            = true
+lair	 		        = 1
+
+;tunnel to deeper forest - little mine
+[red_smart_terrain_monsters_2]:default_resource ; default_lair
+sim_avail 	            = true
+surge					= 1
+
+[red_smart_terrain_monsters_3]:default_lair
+sim_avail 	            = true
+
+;----------- << LIMANSK >> ------------
+;---------	SIMULATION	--------
+;tunnel near Limansk-Red Forest lc
+[lim_smart_terrain_1]:weak_lair		;trx edited
+sim_avail 	            = true
+surge		            = 1
+stalker 	            = 1 
+csky		            = 1  
+killer			        = 1
+bandit 			        = 1
+
+[lim_smart_terrain_10]:default_base
+sim_avail 	            = true
+surge 			        = 1
+resource				= 1
+stalker 		        = 1 
+csky			        = 1 
+ecolog			        = 1 
+monolith		        = 1
+killer			        = 1
+monolith_heli	        = 1
+
+[lim_smart_terrain_3]:default_base
+sim_avail 	            = true
+surge 		            = 1
+stalker 	            = 1 
+csky		            = 1 
+ecolog		            = 1 
+killer		            = 1
+
+[lim_smart_terrain_4]:default_base
+sim_avail 	            = true
+resource 	            = 1
+surge 		            = 1
+stalker 	            = 1 
+csky		            = 1 
+ecolog		            = 1 
+monolith	            = 1
+killer		            = 1
+bandit 		            = 1
+
+[lim_smart_terrain_5]:default_base
+sim_avail 	            = true
+surge 		            = 1
+stalker 	            = 1 
+csky		            = 1 
+ecolog		            = 1 
+monolith	            = 1
+killer		            = 1
+
+
+[lim_smart_terrain_6]:default_base
+sim_avail 	            = true
+surge 			        = 1
+stalker 		        = 1 
+csky			        = 1  
+monolith		        = 1
+monolith_heli	        = 1
+
+[lim_smart_terrain_7]:default_lair
+sim_avail 	            = true
+
+[lim_smart_terrain_8]:default_lair
+sim_avail 	            = true
+
+;construction site
+[lim_smart_terrain_9]:default_territory ; default_base
+sim_avail 	            = true
+surge 			        = 1
+stalker 		        = 1 
+csky			        = 1  
+monolith		        = 1
+killer			        = 0
+monolith_heli	        = 1
+
+;----------- << HOSPITAL >> ------------
+;---------	SIMULATION	--------
+[katacomb_smart_terrain]:default_base
+sim_avail 	            = true
+surge 			        = 1
+monolith		        = 1
+monolith_heli	        = 1
+
+
+;----------- << DEAD CITY >> ------------
+;---------	SIMULATION	--------
+[cit_bandits]:default_lair
+sim_avail 	            = true
+surge 		            = 1
+;bandit		            = 1
+;army 		            = 1 
+;killer 		        = 1 
+;monolith 	            = 1
+
+[cit_bandits_2]:default_lair
+sim_avail 	            = true
+
+[cit_kanaliz1]:default_lair
+sim_avail 	            = true
+
+[cit_kanaliz2]:default_lair
+sim_avail 	            = true
+
+[cit_killers]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+resource		= 1
+killer		            = 5
+
+[cit_killers_2]:default_resource
+sim_avail 	            = true
+killer			        = 1
+
+
+[cit_killers_vs_bandits]:default_base
+sim_avail 	            = true
+lair			        = 1
+surge 		            = 1
+bandit		            = 1
+army 		            = 1 
+killer 		            = 2 
+;monolith 	            = 1
+zombied		            = 1
+
+; bugged npc jobs/nothing in here, use only for mutants
+[zombie_smart_ds_mlr_1]:default_lair
+sim_avail				= true
+
+; bugged npc jobs, use only for mutants
+[zombie_smart_ds_mlr_2]:default_lair
+sim_avail				= true
+
+;----------- << RADAR >> ------------
+;---------	SIMULATION	--------
+[rad2_loner_0000]:default_lair
+sim_avail 	            = true
+monolith	            = 1
+
+-- monolith roadblock
+[rad2_loner_0001]:default_territory
+sim_avail 	            = true
+surge                   = 1
+lair					= 1
+monolith	            = 1
+
+[rad2_loner_0002]:default_lair
+sim_avail 	            = true
+monolith	            = 1
+
+[rad2_prip_teleport]:default_base
+sim_avail 	            = true
+surge 		            = 1
+stalker 	            = 1 
+csky		            = 0 
+ecolog		            = 0 
+monolith	            = 1
+killer		            = 0
+
+;bugged jobs, do not use
+[rad2_rad_prip_road]:default
+sim_avail				= false
+
+[rad_after_valley]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[rad_antenna_camper]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[rad_antenna_monolith]:default_base
+sim_avail 	            = true
+surge 			        = 1
+monolith		        = 1
+monolith_heli	        = 1
+
+[rad_antenna_patrol]:default_base
+sim_avail 	            = true
+surge 		            = 1
+monolith	            = 1
+
+[rad_bloodsucker]:default_lair
+sim_avail 	            = true
+monolith	            = 0
+zombied			        = 1
+
+[rad_entrance]:default_territory	;trx edited
+sim_avail 	            = true
+surge 		            = 1
+zombied			        = 1
+
+[rad_pseudodogs]:default_lair
+sim_avail 	            = true 
+lair					= 1 
+zoo_monster				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 1
+monster_vegetarian		= 1
+monster_zombied_day		= 1
+monster_zombied_night	= 1
+monster_special			= 1
+
+[rad_snork1]:default_lair
+sim_avail 	            = true
+monolith	            = 0
+zombied			        = 1
+
+[rad_snork2]:default_lair
+sim_avail 	            = true
+monolith	            = 0
+zombied			        = 1
+
+[rad_valley]:default_lair
+sim_avail 	            = true
+surge 		            = 1
+monolith	            = 0
+zombied			        = 1
+
+[rad_valley_dogs]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+monolith	            = 1
+
+[rad_zombied1]:default_lair
+sim_avail 	            = true
+monolith	            = 0
+zombied			        = 1
+
+[rad_zombied2]:default_lair
+sim_avail 	            = true
+surge 		            = 1
+monolith	            = 0
+zombied			        = 1
+
+; too close to level changer
+[rad_freedom_vs_duty]:default
+sim_avail				= false
+
+;bugged jobs, do not use
+[rad_rusty_forest_center]:default
+sim_avail				= false
+
+;----------- << BUNKER-LAB X-19 SMARTIES >> ------------
+[bun_krovosos_nest]:default_lair
+sim_avail 	            = true
+territory	            = 1 
+
+[bun2_st_bloodsucker]:default_lair
+sim_avail 	            = {+bar_deactivate_radar_done} true, false
+monolith 	            = 1 
+ecolog 		            = 1
+stalker		            = 1
+;army		            = 1
+territory 	            = 1
+
+[bun2_tushkano_lair]:default_lair
+sim_avail 	            = {+bar_deactivate_radar_done} true, false
+monolith 	            = 1 
+ecolog 		            = 1
+stalker		            = 1
+;army		            = 1
+territory 	            = 1
+
+
+;----------- << PRIPYAT >> ------------
+;---------	SIMULATION	--------
+[pri_depot]:default_base
+sim_avail 	            = true
+surge 			        = 1
+monolith		        = 1
+monolith_heli	        = 1
+
+;palace of culture, near pri_monolith, unsure if used of unported mlr stuff
+;there's a special job for a special npc but dunno if it's ever used
+; just in case, do not use until tested properly
+[mlr_terrain]:default
+sim_avail				= false
+
+[pri_monolith]:default_base
+sim_avail 	            = true
+surge                   = 1
+
+[pri_smart_bloodsucker_lair1]:default_lair
+sim_avail 	            = true
+territory	            = 1 
+surge                   = 1
+
+[pri_smart_controler_lair1]:default_base ; default_territory
+sim_avail 	            = true
+surge 		            = 1
+
+[pri_smart_controler_lair2]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[pri_smart_giant_lair1]:default_resource
+sim_avail 	            = true
+surge 		            = 1
+
+[pri_smart_monolith_stalker2]:default_lair
+sim_avail 	            = true
+
+[pri_smart_monolith_stalker3]:default_lair
+sim_avail 	            = true
+
+[pri_smart_monolith_stalker4]:default_lair
+sim_avail 	            = true
+
+[pri_smart_monolith_stalker6]:default_territory
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli 	        = 1
+
+[pri_smart_monster_lair1]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[pri_smart_neutral_stalker1]:default_lair ; default_territory
+sim_avail 	            = true
+stalker		            = 1
+dolg		            = 1 
+freedom		            = 1 
+ecolog		            = 1 
+csky		            = 1
+
+[pri_smart_pseudodog_lair1]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[pri_smart_snork_lair1]:default_lair
+sim_avail 	            = true
+surge 		            = 1
+
+[pri_smart_snork_lair2]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+; hotel polyssa
+[pri_smart_tushkano_lair1]:default_territory ; default_lair
+sim_avail 	            = true
+surge                   = 1
+
+; do not use, TODO some jobs to fix
+[hotel_poless_smart_alife]:default
+sim_avail 	            = false
+
+; do not use, snipers in inacessible buldings/roofs
+; maybe useful for tasks or static squad but not for general use
+; TODO also a couple of jobs to disable just in case (sitting on ground)
+[monolith_snipers_smart_1_mlr]:default_territory
+sim_avail 	            = false
+
+
+;----------- << STANCIA_1 >> ------------
+;---------	SIMULATION	--------
+[aes_smart_terrain_monolit_blockpost]:default_territory
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes_smart_terrain_monolit_blockpost2]:default_lair
+sim_avail 	            = true
+
+[aes_smart_terrain_monolit_blockpost4]:default_base
+sim_avail 	            = true
+surge 			        = 1
+resource				= 1
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes_smart_terrain_monsters1]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[aes_smart_terrain_monsters2]:default_lair
+sim_avail 	            = true
+territory	            = 0
+
+[aes_smart_terrain_monsters3]:default_lair
+sim_avail 	            = true
+
+[aes_smart_terrain_monsters4]:default_lair
+sim_avail 	            = true
+
+[aes_smart_terran_soldier]:default_territory
+sim_avail 	            = true
+army 		            = 1
+army_heli	            = 1
+
+
+[aes_smart_terran_soldier2]:default_lair
+sim_avail 	            = true
+all			            = 0
+army 		            = 1
+
+;----------- << SARCOFAG >> ------------
+
+[sar_monolith_general]:default_territory
+sim_avail               = {+sar_secret_door_find} true, false
+monolith 	            = 1 
+stalker		            = 1
+;army		            = 1
+ecolog		            = 1
+lair 		            = 1 
+
+[sar_monolith_sklad]:default_territory
+sim_avail               = {+sar_secret_door_find} true, false
+lair                    = 1 
+
+[sar_monolith_poltergeists]:default_lair
+sim_avail               = {+sar_secret_door_find} true, false
+
+[sar_monolith_bloodsuckers]:default_lair
+sim_avail               = {+sar_secret_door_find} true, false
+monolith 	            = 1 
+stalker		            = 1
+;army		            = 1
+ecolog		            = 1
+territory	            = 1
+
+;----------- << MONOLITH CONTROL >> ------------
+[sar_monolith_guard]:default_territory
+sim_avail               = {+sar_monolith_generator_find} true, false
+monolith 	            = 1 
+stalker		            = 1
+;army		            = 1
+ecolog		            = 1
+lair 		            = 1 
+
+[sar_monolith_zombies]:default_lair
+sim_avail               = {+sar_monolith_generator_find} true, false
+monolith 	            = 1 
+stalker		            = 1
+;army		            = 1
+ecolog		            = 1
+territory 	            = 1
+
+;----------- << STANCIA_2 >> ------------
+;---------	SIMULATION	--------
+[aes2_monolith_camp1]:default_territory
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes2_monolith_camp2]:default_territory
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes2_monolith_camp3]:default_resource
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes2_monolith_camp4]:default_resource
+sim_avail 	            = true
+monolith		        = 1
+monolith_heli	        = 1
+
+[aes2_monolith_snipers_1]:default_territory
+sim_avail 	            = true
+
+[aes2_monolith_snipers_2]:default_lair
+sim_avail 	            = true
+
+[aes2_monolith_snipers_3]:default_resource
+sim_avail 	            = true
+
+[aes2_monsters1]:default_lair
+sim_avail 	            = true
+
+[aes2_monsters2]:default_lair
+sim_avail 	            = true
+
+
+;----------- << GENERATORS >> ------------
+;---------	SIMULATION	--------
+[gen_smart_terrain_lab_entrance]:default_base
+sim_avail 	            = true
+surge 			        = 1
+resource		= 1
+monolith		        = 1
+monolith_heli	        = 1
+
+[gen_smart_terrain_cemetery]:default_resource ; default_lair
+sim_avail 	            = true
+lair 					= 1
+
+[gen_smart_terrain_forest]:default_lair
+sim_avail 	            = true
+
+[gen_smart_terrain_junk]:default_lair
+sim_avail 	            = true
+
+[gen_smart_terrain_lab_entrance_2]:default_lair
+sim_avail 	            = true
+
+[gen_smart_terrain_military]:default_resource
+sim_avail 	            = true
+
+[gen_smart_terrain_urod]:default_lair
+sim_avail 	            = true
+
+;----------- << WARLAB >> ------------
+[warlab_common_consciousness_smart_terrain]:default_territory ; default_base
+sim_avail               = false
+
+
+;--------------------------------------------------------------------------------
+;----------- << Zaton >> ------------
+
+;base
+[zat_stalker_base_smart]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+stalker		            = 1 
+csky		            = 1 
+dolg 		            = 1 
+monolith	            = 0
+bandit		            = 0
+renegade		        = 0
+
+;no sim
+[zat_medic_home_smart]:default_territory
+sim_avail               = false
+
+[zat_b7_stalker_raider]:default_territory
+sim_avail               = false
+
+;technical, but with sim available, surge too
+[zat_b33]:default_lair
+sim_avail               =  false
+
+[zat_a23_smart_terrain]:default_lair ; default_territory
+sim_avail               = false
+
+;Stalker Barge SW of Skadovsk
+[zat_b7]:default_base
+sim_avail 	            = true
+surge                   = 1
+
+[zat_b40_smart_terrain]:default_base
+sim_avail 	            = true
+surge                   = 1
+killer					= 1
+
+; secret cave
+[zat_b28]:default_lair
+sim_avail 	            = false
+surge                   = 1
+
+;!!!
+[zat_b42_smart_terrain]:default_lair ; default_territory
+sim_avail 	            = true
+surge                   = 1
+territory 	            = 1
+
+;Noahs barge
+[zat_b18]:default_base
+sim_avail 	            = false
+surge                   = 1
+
+[zat_b101]:default_resource
+sim_avail 	            = true
+surge                   = 1
+territory	            = 1 
+
+[zat_b38u]:default_lair ; default_territory
+sim_avail               = false
+
+[zat_b38]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+;regular smarts
+[zat_b5_smart_terrain]:default_base ; default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[zat_b106_smart_terrain]:default_territory
+sim_avail 	            = true
+lair					= 1
+
+[zat_b52]:default_territory
+sim_avail 	            = true
+territory	            = 1 
+
+;Mercenary Substation Workshop
+[zat_b103_merc_smart]:default_base
+sim_avail 	            = true
+surge		            = 1
+
+[zat_b104_zombied]:default_territory
+sim_avail 	            = true
+lair					= 1
+
+[zat_b14_smart_terrain]:default_resource
+sim_avail 	            = true
+
+[zat_b20_smart_terrain]:default_resource
+sim_avail 	            = true
+territory	            = 1 
+
+[zat_b53]:default_resource
+sim_avail 	            = true
+territory 	            = 1 
+
+[zat_b12]:default_lair
+sim_avail 	            = true
+
+[zat_b54]:default_resource
+sim_avail 	            = true
+territory 	            = 1
+
+[zat_b55]:default_resource
+sim_avail 	            = true
+territory 	            = 1
+
+[zat_b100]:default_resource
+sim_avail 	            = true
+surge		            = 1
+
+[zat_b39]:default_resource
+sim_avail 	            = true
+territory 	            = 1
+lair		            = 1 
+
+
+[zat_b56]:default_resource
+sim_avail 	            = true
+
+[zat_a1]:default_lair ; default_territory
+sim_avail 	            = true
+
+;---------	SIMULATION	--------
+
+[zat_sim_1]:default_lair
+sim_avail 	            = true
+
+[zat_sim_2]:default_lair
+sim_avail 	            = true
+
+[zat_sim_3]:default_lair
+sim_avail 	            = true
+
+[zat_sim_4]:default_lair
+sim_avail 	            = true
+
+[zat_sim_5]:default_lair
+sim_avail 	            = true
+
+[zat_sim_6]:default_lair
+sim_avail 	            = true
+
+[zat_sim_7]:default_lair
+sim_avail 	            = true
+
+[zat_sim_8]:default_lair
+sim_avail 	            = true
+
+[zat_sim_9]:default_lair
+sim_avail 	            = true
+
+[zat_sim_10]:default_lair
+sim_avail 	            = true
+
+[zat_sim_11]:default_lair
+sim_avail 	            = true
+
+[zat_sim_12]:default_lair
+sim_avail 	            = true
+
+[zat_sim_13]:default_lair
+sim_avail 	            = true
+
+[zat_sim_14]:default_lair
+sim_avail 	            = true
+
+[zat_sim_15]:default_lair
+sim_avail 	            = true
+
+[zat_sim_16]:default_lair
+sim_avail 	            = true
+
+[zat_sim_17]:default_lair
+sim_avail 	            = true
+
+[zat_sim_18]:default_lair
+sim_avail 	            = true
+
+[zat_sim_19]:default_lair
+sim_avail 	            = true
+
+[zat_sim_20]:default_lair
+sim_avail 	            = true
+
+[zat_sim_21]:default_lair
+sim_avail 	            = true
+
+[zat_sim_22]:default_lair
+sim_avail 	            = true
+
+[zat_sim_23]:default_lair
+sim_avail 	            = true
+
+[zat_sim_24]:default_lair
+sim_avail 	            = true
+
+[zat_sim_25]:default_territory
+sim_avail 	            = true
+lair 	    	        = 1
+
+[zat_sim_26]:default_lair
+sim_avail 	            = true
+
+[zat_sim_27]:default_lair
+sim_avail 	            = true
+
+[zat_sim_28]:default_lair
+sim_avail 	            = true
+
+[zat_sim_29]:default_lair
+sim_avail 	            = true
+
+[zat_sim_30]:default_lair
+sim_avail 	            = true
+
+;--------------------------------------------------------------------------------
+;----------- << Jupiter >> ------------
+
+[jup_a10_smart_terrain]:default_base
+sim_avail 	            = true
+surge		            = 1
+stalker		            = 1 
+bandit		            = 1 
+csky		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+renegade				= 1
+
+;Bandit Outpost
+[jup_a12]:default_base
+sim_avail 	            = true
+surge		            = 1
+bandit		            = 2
+renegade		        = 1
+
+[jup_a6]:default_base
+sim_avail 	            = true 
+surge 		            = 1
+stalker		            = 1 
+csky		            = 0 
+ecolog		            = 1
+freedom 	            = 1
+monolith	            = 0
+bandit		            = 0
+dolg		            = 0
+
+[jup_b1]:default_territory
+sim_avail	            = true
+surge		            = 1
+lair 					= 1
+
+[jup_b19]:default_territory
+sim_avail 	            = true
+zombied 	            = 1
+
+[jup_b200]:default_territory
+sim_avail	            = true
+surge		            = 1
+territory 	            = 1
+stalker		            = 1 
+bandit		            = 1 
+csky		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+
+[jup_b202]:default_territory
+sim_avail               =	true
+
+[jup_b203]:default_territory
+sim_avail               = {+jup_b16_oasis_artifact_spawn} true, false
+surge		            = 1
+
+[jup_b204]:default_territory
+sim_avail 	            = true
+
+[jup_b205_smart_terrain]:default_territory ; default_lair
+sim_avail 	            = true
+surge		            = 1
+
+[jup_b206]:default_resource
+sim_avail 	            = true
+
+[jup_b207]:default_territory
+sim_avail 	            = true
+
+; pretty much overlaps jup_b208, do not use
+[depo_terrain]:default
+sim_avail = false
+
+[jup_b208]:default_base
+sim_avail 	            = {+lttz_hb_isg_leader_in_jup -lttz_hb_leaving_jup_done} false, true
+surge		            = 1
+lair					= 1
+
+[jup_b209]:default_resource
+sim_avail 	            = true
+
+[jup_b211]:default_resource
+sim_avail 	            = true
+
+[jup_b212]:default_territory
+sim_avail 	            = true
+lair					= 1
+
+[jup_b25]:default_resource
+sim_avail 	            = true
+
+[jup_b32]:default_resource
+sim_avail 	            = true
+
+[jup_b4]:default_lair ; default_territory
+sim_avail 	            = true
+
+[jup_b41]:default_base
+sim_avail 	            = true
+surge		            = 1
+stalker		            = 1 
+bandit		            = 0 
+csky		            = 1 
+dolg 		            = 0 
+freedom 	            = 0
+killer 		            = 1
+ecolog		            = 1
+monolith	            = 0
+
+[jup_b46]:default_territory
+sim_avail 	            = true
+
+[jup_b47]:default_lair ; default_territory
+sim_avail 	            = true
+lair					= 1
+
+[jup_b6_anom_2]:default_resource
+sim_avail 	            = true
+
+;technical
+
+[jup_b200_tushkan_smart_terrain]:default_lair
+sim_avail 	            = true
+
+[jup_b207_depot_attack]:default_lair ; default_territory
+sim_avail               = false
+
+[jup_b219]:default_territory
+sim_avail               = false
+lair					= 1
+
+[jup_b8_smart_terrain]:default_territory
+sim_avail               = false
+lair					= 1
+
+[jup_b205_smart_terrain_tushkano]:default_lair ; default_territory
+sim_avail               = false
+
+[jup_a12_merc]:default_lair ; default_territory
+sim_avail               = false
+
+[jup_a9]:default_territory ; default_lair
+sim_avail               =  false
+lair				= 1
+
+;---------	SIMULATION	--------
+
+[jup_sim_1]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_2]:default_lair		;edited	
+sim_avail 	            = true
+
+[jup_sim_3]:default_lair
+sim_avail 	            = true
+
+[jup_sim_4]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_5]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_6]:default_lair ; default_territory
+sim_avail 	            = true
+
+[jup_sim_7]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_8]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_9]:default_lair
+sim_avail 	            = true
+
+[jup_sim_10]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_11]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_12]:default_lair
+sim_avail 	            = true
+
+[jup_sim_13]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_14]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_15]:default_lair
+sim_avail 	            = true
+
+[jup_sim_16]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_17]:default_resource
+sim_avail 	            = true
+lair	 	            = 1
+
+[jup_sim_18]:default_resource ; default_lair
+sim_avail 	            = true
+
+[jup_sim_19]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_20]:weak_lair
+sim_avail 	            = true
+
+[jup_sim_21]:default_lair
+sim_avail 	            = true
+
+; ---------------------------  Pripyat  ------------------------------------
+; --------------------------------------------------------------------------
+
+[pri_a15]:default_territory
+sim_avail 	            = true
+
+[pri_a16]:default_base
+sim_avail 	            = true
+stalker		            = 1 
+bandit		            = 1 
+csky		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+
+[pri_a17]:default_territory
+sim_avail 	            = true
+
+[pri_a18_smart_terrain]:default_base
+sim_avail 	            = true
+surge                   = 1
+monolith                = 0
+
+[pri_a21_smart_terrain]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[pri_a22_smart_terrain]:default_lair ; default_territory
+sim_avail 	            = true
+
+[pri_a25_smart_terrain]:default_territory
+sim_avail 	            = true
+
+[pri_b301]:default_resource
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b302]:default_resource
+sim_avail 	            = true
+
+[pri_b303]:default_resource
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b304]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b306]:default_resource
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b307]:default_resource
+sim_avail 	            = true
+
+[pri_b35_mercs]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b36_smart_terrain]:default_base ; default_territory
+sim_avail 	            = true
+surge 		            = 1
+zombied 	            = 1
+monolith	            = 1 
+
+[pri_sim_1]:default_base ; default_lair
+sim_avail 	            = true
+surge                   = 1
+
+[pri_sim_2]:default_lair
+sim_avail 	            = true
+
+[pri_sim_3]:default_lair
+sim_avail 	            = true
+
+[pri_sim_4]:default_lair
+sim_avail 	            = true
+
+[pri_sim_5]:default_lair
+sim_avail 	            = true
+
+[pri_sim_6]:default_lair
+sim_avail 	            = true
+
+[pri_sim_7]:default_lair
+sim_avail 	            = true
+
+[pri_sim_8]:default_lair
+sim_avail 	            = true
+
+[pri_sim_9]:default_lair
+sim_avail 	            = true
+
+[pri_sim_10]:default_lair
+sim_avail 	            = true
+
+[pri_sim_11]:default_lair
+sim_avail 	            = true
+
+[pri_sim_12]:default_lair
+sim_avail 	            = true
+
+[pri_b35_military]:default_territory
+sim_avail 	            = true
+surge                   = 1
+
+[pri_b305_dogs]:default_territory
+sim_avail               = false
+
+[pri_b304_monsters_smart_terrain]:default_territory
+sim_avail 	            = true
+
+[pri_a20]:default_territory
+sim_avail 	            = true
+
+[pri_a28_heli]:default_lair ; default_territory
+sim_avail 	            = true
+
+[pri_a28_base]:default ; default_territory
+sim_avail 	            = true
+
+[pri_a28_shop]:default_territory
+sim_avail 	            = true
+
+[pri_a28_arch]:default_lair ; default_territory
+sim_avail 	            = true
+
+[pri_a28_school]:default_territory
+sim_avail 	            = true
+
+[pri_a28_evac]:default_lair ; default_territory
+sim_avail 	            = true
+
+;lab x8 building, bugged and overlapping jobs, do not use
+[kbo_terrain]:default_territory
+sim_avail 	            = false
+
+;lab X-8
+[lx8_smart_terrain]:default_territory
+sim_avail               = {+lx8_actor_in_lab +actor_left_labx8} true, false
+all                     = 1
+lair                    = 1 
+
+
+;underpass
+[pas_b400_elevator]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+[pas_b400_track]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+all			            = 1
+territory 	            = 1
+
+[pas_b400_downstairs]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+[pas_b400_tunnel]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+[pas_b400_hall]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+all			            = 1
+
+[pas_b400_way]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+[pas_b400_canalisation]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+[pas_b400_fake]:default_lair
+sim_avail               = {+actor_pass_jupiter_exit_find +actor_pass_pripyat_exit_find} true, false
+
+
+;--<< TRUCKS CEMETERY >>--
+
+[trc_sim_1]:default_territory
+sim_avail 	            = true
+lair			        = 1
+stalker		            = 1 
+bandit		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+army		            = 1
+
+
+[trc_sim_2]:default_base
+sim_avail 	            = true
+surge	                = 1
+stalker		            = 1 
+bandit		            = 1 
+dolg 		            = 1 
+freedom 	            = 1
+army		            = 1
+
+[trc_sim_3]:default_lair
+sim_avail 	            = true
+dolg			        = 2
+zombied			        = 1
+
+[trc_sim_4]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+lair	 		        = 1
+csky			        = 1
+zombied			        = 1
+
+[trc_sim_5]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[trc_sim_6]:default_lair
+sim_avail 	            = true
+surge	                = 1
+
+[trc_sim_7]:default_lair
+sim_avail 	            = true
+
+[trc_sim_8]:default_resource
+sim_avail 	            = true
+lair	 	            = 1
+stalker 		        = 1
+dolg			        = 1
+freedom			        = 1
+ecolog			        = 1
+csky			        = 1
+zombied			        = 1
+
+[trc_sim_9]:default_lair
+sim_avail 	            = true
+
+[trc_sim_10]:default_resource
+sim_avail 	            = true
+ecolog			        = 1
+stalker 		        = 1
+lair	 		        = 1
+csky			        = 1
+
+[trc_sim_11]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[trc_sim_12]:default_lair
+sim_avail 	            = true
+
+[trc_sim_13]:default_resource
+sim_avail 	            = true
+lair	 		        = 1
+dolg			        = 1
+stalker 		        = 1
+zombied			        = 1
+
+[trc_sim_14]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[trc_sim_15]:default_lair
+sim_avail 	            = true
+
+[trc_sim_16]:default_lair
+sim_avail 	            = true
+
+[trc_sim_17]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[trc_sim_18]:default_lair ; default_territory
+sim_avail 	            = true
+stalker		            = 1 
+zombied			        = 1
+
+[trc_sim_19]:default_lair
+sim_avail 	            = true
+zombied			        = 1
+
+[trc_sim_20]:default_base
+sim_avail 	            = true
+surge		            = 1
+bandit 	            	= 1
+renegade                = 1
+
+[trc_sim_21]:default_lair
+sim_avail 	            = true
+
+
+;-- for MLR 6.2
+[pol_sim_1]:default
+sim_avail 	            = false
+
+[pol_smart_terrain_1_1]:default
+sim_avail 	            = false
+
+[pol_smart_terrain_1_2]:default
+sim_avail 	            = false
+
+[pol_smart_terrain_1_3]:default_resource
+sim_avail 	            = false
+
+[pol_smart_terrain_2_1]:default
+sim_avail 	            = false
+zoo_monster				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 1
+monster_vegetarian		= 1
+monster_zombied_day		= 1
+monster_zombied_night	= 1
+monster_special			= 1
+
+[pol_smart_terrain_2_2]:default
+sim_avail 	            = false
+zoo_monster				= 1
+monster					= 1
+monster_predatory_day 	= 1
+monster_predatory_night = 1
+monster_vegetarian		= 1
+monster_zombied_day		= 1
+monster_zombied_night	= 1
+monster_special			= 1
+
+
+;-- for MLR 6.2 (disabled) TODO: fix squads can't build path to Meadow
+;[pol_sim_1]:default_base
+;sim_avail 	            = true
+;territory	            = 1
+;
+;[pol_smart_terrain_1_1]:default_base
+;sim_avail 	            = true
+;territory	            = 1
+;surge		            = 1
+;stalker		            = 1 
+;bandit		            = 1 
+;dolg 		            = 1 
+;freedom 	            = 1
+;army		            = 1
+;
+;[pol_smart_terrain_1_2]:default_base
+;sim_avail 	            = true
+;territory	            = 1
+;surge		            = 1
+;stalker		            = 1 
+;bandit		            = 1 
+;dolg 		            = 1 
+;freedom 	            = 1
+;army		            = 1
+;
+;[pol_smart_terrain_1_3]:default_resource
+;sim_avail 	            = true
+;territory	            = 1
+;surge		            = 1
+;stalker		            = 1 
+;bandit		            = 1 
+;dolg 		            = 1 
+;freedom 	            = 1
+;army		            = 1
+;
+;[pol_smart_terrain_2_1]:default_lair
+;sim_avail 	            = true
+;territory	            = 1
+;surge		            = 1
+;stalker		            = 1 
+;bandit		            = 1 
+;dolg 		            = 1 
+;freedom 	            = 1
+;army		            = 1
+;
+;[pol_smart_terrain_2_2]:default_lair
+;sim_avail 	            = true
+;territory	            = 1
+;surge		            = 1
+;stalker		            = 1 
+;bandit		            = 1 
+;dolg 		            = 1 
+;freedom 	            = 1
+;army		            = 1

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/dialogs.script
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/dialogs.script
@@ -1,0 +1,2707 @@
+-- ============================================================
+--
+-- Script Functions for Task Dialogs  (dialogs.script)
+--	CoC 1.4.22 - DoctorX Questlines 1.24
+--
+--	Modified by: DoctorX, av661194
+--	Last revised: February 16, 2017
+--
+-- ============================================================
+
+local goodwill_trust_limit = 200
+
+
+function can_do_task_mysteries_of_the_zone(a,b)
+	-- Only give the story quests to factions in this table.
+	local actor_comm = character_community(db.actor):sub(7)
+	local story_factions = {
+		["csky"] = true,
+		["dolg"] = true,
+		["ecolog"] = true,
+		["freedom"] = true,
+		["killer"] = true,
+		["stalker"] = true,
+	}
+	if actor_comm and story_factions[actor_comm] and (not has_alife_info("story_mode_disabled")) then
+		return true
+	end
+	return false
+end
+
+function give_task_mysteries_of_the_zone(a,b)
+	task_manager.get_task_manager():give_task("mar_find_doctor_task")
+end
+
+function warfare_disabled(a,b)
+	if _G.WARFARE then
+		return false
+	end
+	return true
+end
+
+-------------------------------------------
+-- Task stacking check
+-------------------------------------------
+local mark_task_per_npc = {}
+function get_npc_task_limit()
+	return tonumber(ui_options.get("gameplay/general/max_tasks") or 2)
+end
+
+function has_tasks_by_npc(a,b)
+	local npc = who_is_npc(a, b)
+	axr_task_manager.generate_ongoing_tasks(npc,nil)
+	return axr_task_manager.ongoing_tasks[npc:id()] and (#axr_task_manager.ongoing_tasks[npc:id()] >= get_npc_task_limit()) or false
+end
+
+function not_has_tasks_by_npc(a,b)
+	return (not has_tasks_by_npc(a,b))
+end
+
+function confirm_task_stack(a,b)
+	local npc = who_is_npc(a, b)
+	mark_task_per_npc[npc:id()] = true
+end
+
+function clear_task_stack(a,b)
+	local npc = who_is_npc(a, b)
+	mark_task_per_npc[npc:id()] = nil
+end
+
+function check_task_stack(a,b)
+	local npc = who_is_npc(a, b)
+	if not_has_tasks_by_npc(a,b) then
+		mark_task_per_npc[npc:id()] = nil
+	end
+	return (mark_task_per_npc[npc:id()] ~= true)
+end
+
+
+-- Global var to store last available task id:
+last_task_id = nil
+
+-- Determine if actor has npc task:
+function drx_sl_dont_has_npc_task( a, b )
+
+	local npc = who_is_npc(a, b)
+	local se_obj = npc and alife( ):object( npc:id( ) )
+	local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+	if not ( giver_id ) then
+		return false
+	end
+	if ( load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) > 0 ) then
+		return false
+	end
+
+	return true
+
+end
+
+-- Determine if actor is same faction as npc (true faction):
+function drx_sl_actor_can_change_this_faction( a, b )
+
+	-- Get npc faction:
+	local npc = who_is_npc( a, b )
+	local npc_faction = character_community( npc )
+
+	-- Special check for Traders
+	if ( npc_faction == "trader" ) then
+		local se_squad = get_object_squad(npc)
+		npc_faction = se_squad and se_squad.player_id or npc_faction
+		if ( npc_faction == "trader" ) then
+			npc_faction = "stalker"
+		end
+	end
+
+	-- Get player faction:
+	local actor_faction = get_actor_true_community()
+	
+	-- Check if factions are same, or enemies (disguise case)
+	if ( actor_faction == npc_faction ) or game_relations.is_factions_enemies( actor_faction , npc_faction ) then
+		return false
+	else
+		return true
+	end
+
+end
+
+-- Determine if actor has completed current storyline task:
+function drx_sl_actor_has_finished_task( a, b )
+
+	local npc = who_is_npc( a, b )
+
+	local tsk = axr_task_manager and axr_task_manager.drx_sl_get_finished_task( npc )
+	if ( tsk == nil ) then
+		return false
+	end
+
+	return true
+
+end
+
+-- Determine if actor has completed change factions task:
+function drx_sl_actor_has_finished_cf_task( a, b )
+
+	local npc = who_is_npc( a, b )
+
+	local tsk = axr_task_manager and axr_task_manager.drx_sl_get_finished_cf_task( npc )
+	if ( tsk == nil ) then
+		return false
+	end
+
+	return true
+
+end
+
+-- Determine if end game task has been reached or should be given:
+function drx_sl_is_endgame( a, b )
+
+	if ( (load_var( db.actor, "drx_sl_current_task_number", 1 ) >= load_var( db.actor, "drx_sl_total_task_number", 1 )) and (has_alife_info( "bar_deactivate_radar_done" )) ) then
+		return true
+	end
+
+	return false
+
+end
+
+-- Determine if end game task has been reached or should be given:
+function drx_sl_is_not_endgame( a, b )
+	return not drx_sl_is_endgame( )
+end
+
+-- Initiate storyline task:
+function drx_sl_text_honcho_has_storyline_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_generate_random_sl_task( npc )
+	last_task_id = task_section
+	
+	-- Tronex, fix for task with info
+	if last_task_id then
+		axr_task_manager.trigger_job_func(last_task_id)
+		axr_task_manager.trigger_fetch_func(last_task_id)
+	end
+	
+	return game.translate_string( task_section and axr_task_manager.get_task_job_description( task_section ) or "st_no_available_task" )
+
+end
+
+-- Initiate mechanic task:
+function drx_sl_text_mechanic_has_ordered_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_get_mechanic_task( npc )
+	last_task_id = task_section
+	
+	-- Tronex, fix for task with info
+	if last_task_id then
+		axr_task_manager.trigger_job_func(last_task_id)
+		axr_task_manager.trigger_fetch_func(last_task_id)
+	end
+	
+	return game.translate_string( task_section and axr_task_manager.get_task_job_description( task_section ) or "st_no_available_task" )
+
+end
+
+-- Initiate a change factions task:
+function drx_sl_text_npc_has_change_factions_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_generate_change_factions_task( npc )
+	last_task_id = task_section
+	return game.translate_string( task_section and axr_task_manager.get_task_job_description( task_section ) or "st_no_available_task" )
+
+end
+
+-- Fetch storyline task text:
+function drx_sl_text_fetch_task( a, b )
+
+	axr_task_manager.trigger_fetch_func( last_task_id )
+
+	local text = game.translate_string( last_task_id and axr_task_manager.get_fetch_task_description( last_task_id ) or "st_about_fetch_task_default" )
+
+	return string.format( text, _FETCH_TEXT or "" ) or ""
+
+end
+
+-- End of storyline task text:
+function drx_sl_text_task_finish( a, b )
+
+	local npc = who_is_npc( a, b )
+
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_get_finished_task( npc )
+	return game.translate_string( task_section and axr_task_manager.get_task_complete_text( task_section ) or ("st_default_task_finished_" .. math.random( 1, 3 )) )
+
+end
+
+-- End of change factions task text:
+function drx_sl_text_cf_task_finish( a, b )
+
+	local npc = who_is_npc( a, b )
+
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_get_finished_cf_task( npc )
+	return game.translate_string( task_section and axr_task_manager.get_task_complete_text( task_section ) or ("st_default_task_finished_" .. math.random( 1, 3 )) )
+
+end
+
+-- End of game text:
+function drx_sl_text_end_game( a, b )
+
+	local npc = who_is_npc( a, b )
+
+	local text_list = {}
+	local i = 1
+	while ( true ) do
+		local text_id = (load_var( db.actor, "drx_sl_start_task", "" ) .. "_endgame_" .. i)
+		local end_game_text = game.translate_string( text_id )
+		if ( end_game_text and end_game_text ~= "" and end_game_text ~= ("_endgame_" .. i) and end_game_text ~= text_id ) then
+			table.insert( text_list, end_game_text )
+		else
+			break
+		end
+		i = (i + 1)
+	end
+
+	if ( #text_list < 1 ) then
+		return game.translate_string( "drx_sl_default_endgame" )
+	end
+
+	return text_list[math.random( 1, #text_list )]
+
+end
+
+-- Set current storyline task to complete:
+function drx_sl_set_finished_task_complete( a, b )
+
+	-- Set current task to complete:
+	local npc = who_is_npc( a, b )
+	axr_task_manager.drx_sl_set_finished_task_complete( npc )
+
+	-- Give actor meet next honcho task:
+	xr_effects.drx_sl_meet_random_honcho( )
+
+end
+
+-- Set current storyline task to complete:
+function drx_sl_set_finished_task_complete_endgame( a, b )
+
+	-- Set current task to complete:
+	local npc = who_is_npc( a, b )
+	axr_task_manager.drx_sl_set_finished_task_complete( npc )
+
+	-- Give actor end game task:
+	xr_effects.drx_sl_find_wish_granter( )
+
+end
+
+-- Set current change faction task to complete:
+function drx_sl_set_finished_cf_task_complete( a, b )
+
+	-- Set current task to complete:
+	local npc = who_is_npc( a, b )
+	axr_task_manager.drx_sl_set_finished_cf_task_complete( npc )
+
+end
+
+-- Determine whether or not a npc has an available task:
+function npc_has_ordered_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	return last_task_id ~= nil or false
+
+end
+
+-- Text to display when a npc has a task to give:
+function text_npc_has_ordered_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_available_task( npc )
+	last_task_id = task_section
+	return game.translate_string( task_section and axr_task_manager.get_task_job_description( task_section ) or "st_no_available_task" )
+
+end
+
+-- Text to display when a npc has a simulation task to give:
+function text_sim_npc_has_ordered_task_to_give( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_available_task( npc, nil, true )
+	last_task_id = task_section
+	return game.translate_string( task_section and axr_task_manager.get_task_job_description( task_section ) or "st_no_available_task" )
+
+end
+
+-- Text to display when a task is finished:
+function text_task_finish( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_finished_task( npc )
+	return game.translate_string( task_section and axr_task_manager.get_task_complete_text( task_section ) or "st_default_task_finished_" .. math.random( 1, 3 ) )
+
+end
+
+-- Text to display when a simulation task is finished:
+function text_sim_task_finish( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_finished_task( npc, true )
+	return game.translate_string( task_section and axr_task_manager.get_task_complete_text( task_section ) or "st_default_task_finished_" .. math.random( 1, 3 ) )
+
+end
+
+-- Determine whether or not the task is a fetch task:
+function task_is_fetch_task( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_id = last_task_id  --axr_task_manager.get_first_available_task(npc)
+	if not ( task_id ) then
+		return false
+	end
+	return axr_task_manager.get_fetch_task_description( task_id ) ~= nil
+
+end
+
+-- Determine whether or not the task is a fetch task:
+function not_task_is_fetch_task( a, b )
+
+	return not task_is_fetch_task( a, b )
+
+end
+
+-- Clear skipped tasks:
+function npc_clear_skipped_tasks( a, b )
+
+	if ( axr_task_manager ) then
+		axr_task_manager.clear_skipped_tasks( )
+	end
+
+end
+
+-- Determine if the actor has a PDA:
+function condition_actor_has_pda( a, b )
+
+	return db.actor:object( "itm_pda_common") or db.actor:object( "itm_pda_uncommon" ) or db.actor:object( "itm_pda_rare" ) or false
+
+end
+
+-- Check if actor has finished task:
+function actor_has_finished_ordered_task( a, b )
+
+	local npc = who_is_npc( a, b )
+	local tsk = axr_task_manager and axr_task_manager.get_first_finished_task( npc )
+	if ( tsk == nil ) then
+		return false
+	end
+	return true
+
+end
+
+-- Check if actor has finished task:
+function actor_has_not_finished_ordered_task( a, b )
+
+	return not actor_has_finished_ordered_task( a, b )
+
+end
+
+-- Check if actor has finished task:
+function actor_sim_has_finished_ordered_task( a, b )
+
+	local npc = who_is_npc( a, b )
+	return axr_task_manager and axr_task_manager.get_first_finished_task( npc, true ) ~= nil or false
+
+end
+
+-- Check if actor has finished task:
+function actor_sim_has_not_finished_ordered_task( a, b )
+
+	return not actor_sim_has_finished_ordered_task( a, b )
+
+end
+
+-- Set current simulation task to complete:
+function npc_sim_set_finished_task_complete( a, b )
+
+	local npc = who_is_npc( a, b )
+	axr_task_manager.set_finished_task_complete( npc, true )
+
+end
+
+-- Give player storyline task:
+function drx_sl_give_sl_task( a, b )
+
+	disable_info( ("drx_sl_meet_honcho_" .. load_var( db.actor, "drx_sl_current_honcho", "" )) )
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_generate_random_sl_task( npc, nil, true )
+	while last_task_id and task_section ~= nil and task_section ~= last_task_id do
+		task_section = axr_task_manager.drx_sl_generate_random_sl_task( npc, true, true )
+	end
+
+	if ( last_task_id ) then
+		printf( ("DRX SL storyline task started: " .. last_task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		save_var( db.actor, "drx_sl_current_task", last_task_id )
+		task_manager.get_task_manager( ):give_task( last_task_id, giver_id )
+
+		-- Register current task giver:
+		if ( (not string.find( "meet_task", last_task_id )) and (not string.find( "find_wish_granter", last_task_id )) ) then
+			local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+			save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+			printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+		end
+
+		last_task_id = nil
+
+	end
+
+end
+
+-- Give player change factions task:
+function drx_sl_give_cf_task( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_generate_change_factions_task( npc, nil, true )
+	while last_task_id and task_section ~= nil and task_section ~= last_task_id do
+		task_section = axr_task_manager.drx_sl_generate_change_factions_task( npc, true, true )
+	end
+
+	if ( last_task_id ) then
+		printf( ("DRX SL change factions task started: " .. last_task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		task_manager.get_task_manager( ):give_task( last_task_id, giver_id )
+
+		-- Register current task giver:
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+
+		last_task_id = nil
+
+	end
+
+end
+
+-- Give the player the current dynamic task:
+function drx_sl_give_mechanic_task( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.drx_sl_get_mechanic_task( npc, nil, true )
+	while last_task_id and task_section ~= nil and task_section ~= last_task_id do
+		task_section = axr_task_manager.drx_sl_get_mechanic_task( npc, true, true )
+	end
+
+	if ( last_task_id ) then
+		printf( ("DRX SL mechanic task started: " .. last_task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		task_manager.get_task_manager( ):give_task( last_task_id, giver_id )
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+		last_task_id = nil
+	end
+
+end
+
+-- Give the player the current dynamic task:
+function npc_give_last_task_id( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_available_task( npc, nil, true )
+	while last_task_id and task_section ~= nil and task_section ~= last_task_id do
+		task_section = axr_task_manager.get_first_available_task( npc, true, true )
+	end
+
+	if ( last_task_id ) then
+		printf( ("DRX SL dynamic task started: " .. last_task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		task_manager.get_task_manager( ):give_task( last_task_id, giver_id )
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+		last_task_id = nil
+	end
+
+end
+
+-- Give the player the current simulation task:
+function npc_sim_give_last_task_id( a, b )
+
+	local npc = who_is_npc( a, b )
+	local task_section = axr_task_manager and axr_task_manager.get_first_available_task( npc, nil, true )
+	while last_task_id and task_section ~= nil and task_section ~= last_task_id do
+		task_section = axr_task_manager.get_first_available_task( npc, true, true )
+	end
+
+	if ( last_task_id ) then
+
+		-- Give player task:
+		printf( ("DRX SL simulation task started: " .. last_task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		task_manager.get_task_manager( ):give_task( last_task_id, giver_id )
+		last_task_id = nil
+
+		-- Register task giver:
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+
+		-- Register hostage task giver:
+		if ( load_var( db.actor, "drx_sl_hostage_giver_needed", false ) ) then
+			save_var( db.actor, ("drx_sl_hostage_giver_" .. giver_id), true )
+			save_var( db.actor, "drx_sl_hostage_giver_needed", false )
+			printf( ("DRX SL: drx_sl_hostage_giver_" .. giver_id .. " registered") )
+		end
+
+	end
+
+end
+
+-- Give the player the first available dynamic task:
+function npc_give_first_available_task( a, b )
+
+	if ( axr_task_manager ) then
+		local npc = who_is_npc( a, b )
+		local task_id = axr_task_manager.npc_give_first_available_ordered_task( npc )
+		if ( not task_id ) then
+			return
+		end
+		printf( ("DRX SL dynamic task started: " .. task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+	end
+
+end
+
+-- Give the player the first available simulation task:
+function npc_sim_give_first_available_task( a, b )
+
+	if ( axr_task_manager ) then
+		local npc = who_is_npc( a, b )
+		local task_id = axr_task_manager.npc_give_first_available_ordered_task( npc, true )
+		if ( not task_id ) then
+			return
+		end
+		printf( ("DRX SL simulation task started: " .. task_id) )
+		local se_obj = npc and alife( ):object( npc:id( ) )
+		local giver_id = se_obj and (se_obj.group_id ~= 65535 and se_obj.group_id or se_obj.id)
+		local giver_task_count = (load_var( db.actor, ("drx_sl_task_giver_" .. giver_id), 0 ) + 1)
+		save_var( db.actor, ("drx_sl_task_giver_" .. giver_id), giver_task_count )
+		printf( ("DRX SL: drx_sl_task_giver_" .. giver_id .. " registered (" .. giver_task_count .. " outstanding)") )
+	end
+
+end
+
+
+
+-- npcs and trade and repair
+function npc_is_trader(a,b)
+    local npc = who_is_npc(a, b)
+	if hide_hud_inventory() then
+		npc:start_trade(db.actor)
+	end
+end
+
+function npc_is_tech(a,b)
+    local npc = who_is_npc(a,b)
+	if hide_hud_inventory() then
+		npc:start_upgrade(db.actor)
+	end
+end
+
+function rescue_hostage(a,b)
+	local npc = who_is_npc(a,b)
+	local squad = get_object_squad(npc)
+	if (squad) then
+		for k in squad:squad_members() do
+			se_save_var(k.id,k.object:name(),"companion_cannot_teleport",nil)
+			axr_task_manager.hostages_by_id[k.id] = nil
+		end
+	else
+		local se_npc = alife_object(npc:id())
+		if (se_npc) then
+			se_save_var(se_npc.id,se_npc:name(),"companion_cannot_teleport",nil)
+			axr_task_manager.hostages_by_id[se_npc.id] = nil
+		end
+	end
+end
+
+-- Dynamic Ordered Task dialog
+-- AVAILABLE TASKS
+function generate_available_tasks(a,b)
+	local npc = who_is_npc(a, b)
+	axr_task_manager.generate_available_tasks(npc,nil)
+	--printf("generate_available_tasks %s",axr_task_manager.available_tasks[npc:id()] and #axr_task_manager.available_tasks[npc:id()])
+end
+
+function sim_generate_available_tasks(a,b)
+	local npc = who_is_npc(a, b)
+	axr_task_manager.generate_available_tasks(npc,true)
+	--printf("sim_generate_available_tasks %s",axr_task_manager.available_tasks[npc:id()] and #axr_task_manager.available_tasks[npc:id()])
+end
+
+function text_npc_has_task(a,b)
+	local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.available_tasks[npc:id()] and axr_task_manager.available_tasks[npc:id()][1]
+	--printf("text_npc_has_task %s",task_id)
+
+	local on_job_descr = task_id and task_manager.task_ini:r_string_ex(task_id,"on_job_descr")
+	if (on_job_descr) then 
+		local cond = xr_logic.parse_condlist(db.actor,"task_manager","condlist",on_job_descr)
+		if (cond) then 
+			xr_logic.pick_section_from_condlist(db.actor,db.actor,cond)
+		end
+	end
+	
+	local fetch = task_id and task_manager.task_ini:r_string_ex(task_id,"fetch_descr")
+	if (fetch) then
+		axr_task_manager.trigger_fetch_func(task_id)
+		return strformat(game.translate_string(fetch),_FETCH_TEXT or "")
+	end
+
+	return game.translate_string(task_id and task_manager.task_ini:r_string_ex(task_id,"job_descr") or "st_no_available_task")
+end
+
+function npc_has_task(a,b)
+	local npc = who_is_npc(a, b)
+	--printf("npc_has_task %s",axr_task_manager.available_tasks[npc:id()] and axr_task_manager.available_tasks[npc:id()][1] ~= nil)
+	return axr_task_manager.available_tasks[npc:id()] and axr_task_manager.available_tasks[npc:id()][1] ~= nil
+end
+
+function npc_give_task(a,b)
+	local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.available_tasks[npc:id()] and axr_task_manager.available_tasks[npc:id()][1]
+	if (task_id) then
+        task_manager.get_task_manager():give_task(task_id,npc:id())
+	end
+	--printf("npc_give_task %s",task_id)
+end
+
+function npc_skip_task(a,b)
+	local npc = who_is_npc(a, b)
+	if (axr_task_manager.available_tasks[npc:id()]) then
+		table.remove(axr_task_manager.available_tasks[npc:id()],1)
+	end
+	--printf("npc_skip_task %s",axr_task_manager.available_tasks[npc:id()] and #axr_task_manager.available_tasks[npc:id()])
+end
+
+-- FINISHED TASK TURN-IN DIALOG
+function actor_has_finished_task(a,b)
+	local npc = who_is_npc(a, b)
+
+	axr_task_manager.generate_finished_tasks(npc,nil)
+
+	--printf("actor_has_finished_task %s",axr_task_manager.finished_tasks[npc:id()] and axr_task_manager.finished_tasks[npc:id()][1] ~= nil)
+	return axr_task_manager.finished_tasks[npc:id()] and axr_task_manager.finished_tasks[npc:id()][1] ~= nil
+end
+
+function sim_actor_has_finished_task(a,b)
+	local npc = who_is_npc(a, b)
+
+	axr_task_manager.generate_finished_tasks(npc,true)
+
+	--printf("sim_actor_has_finished_task %s",axr_task_manager.finished_tasks[npc:id()] and axr_task_manager.finished_tasks[npc:id()][1] ~= nil)
+	return axr_task_manager.finished_tasks[npc:id()] and axr_task_manager.finished_tasks[npc:id()][1] ~= nil
+end
+
+function text_npc_task_finish(a,b)
+	local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.finished_tasks[npc:id()] and axr_task_manager.finished_tasks[npc:id()][1]
+	--printf("text_npc_task_finish %s",task_id)
+	return game.translate_string(task_id and task_manager.task_ini:r_string_ex(task_id,"task_complete_descr") or "st_default_task_finished_"..math.random(1,3))
+end
+
+-- Set current dynamic task to complete:
+function npc_set_finished_task_complete( a, b )
+
+	local npc = who_is_npc( a, b )
+	axr_task_manager.set_finished_task_complete( npc )
+
+end
+
+
+
+-- CANCEL TASKS
+
+function actor_has_ongoing_task(a,b)
+	local npc = who_is_npc(a, b)
+	axr_task_manager.generate_ongoing_tasks(npc,nil)
+	return axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1] ~= nil
+end
+
+function sim_actor_has_ongoing_task(a,b)
+	local npc = who_is_npc(a, b)
+	axr_task_manager.generate_ongoing_tasks(npc,true)
+	return axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1] ~= nil
+end
+
+function text_npc_has_cancel_task(a,b)
+	local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1]
+	--printf("text_npc_has_cancel_task %s",task_id)
+
+	local text = task_id and game.translate_string(task_manager.task_ini:r_string_ex(task_id, "title"))
+	if not (text) then
+		return game.translate_string("st_task_none_active")
+	end
+
+	local fetch = task_id and task_manager.task_ini:r_string_ex(task_id,"fetch_descr")
+	if (fetch) then
+        local sec = load_var(db.actor,task_id.."_fetch")
+        if not (sec) then
+            return text or game.translate_string("st_task_none_active")
+        end
+		local name = ui_item.get_sec_name(sec)
+		return strformat(text,name or "")
+	end
+
+	return text
+end
+
+function npc_has_cancel_task(a,b)
+	local npc = who_is_npc(a, b)
+	--printf("npc_has_cancel_task %s",axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1] ~= nil)
+	return axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1] ~= nil
+end
+
+function npc_cancel_task(a,b)
+	local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1]
+	if (task_id) then
+        task_manager.get_task_manager():set_task_cancelled(task_id)
+	end
+	--printf("npc_cancel_task %s",task_id)
+end
+
+function npc_skip_cancel_task(a,b)
+	local npc = who_is_npc(a, b)
+	if (axr_task_manager.ongoing_tasks[npc:id()]) then
+		table.remove(axr_task_manager.ongoing_tasks[npc:id()],1)
+	end
+	--printf("npc_skip_cancel_task %s",axr_task_manager.ongoing_tasks[npc:id()] and #axr_task_manager.ongoing_tasks[npc:id()])
+end
+
+function text_actor_cancel_task(a,b)
+    local npc = who_is_npc(a, b)
+	local task_id = axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1]
+    return game.translate_string(task_id and task_manager.task_ini:r_string_ex(task_id, "abandoned_reason") or "st_task_default_excuse_cancel_job")
+end
+
+function text_task_cancel(a,b)
+    local npc = who_is_npc(a, b)
+    local task_id = axr_task_manager.ongoing_tasks[npc:id()] and axr_task_manager.ongoing_tasks[npc:id()][1]
+    return game.translate_string(task_id and task_manager.task_ini:r_string_ex(task_id, "abandoned_reply") or "st_default_task_cancel_"..math.random(1,3))
+end
+
+-- This function allows Player to see NPC inventory as if it was a corpse
+function free_trade_with_npc(a,b)
+	local npc = who_is_npc(a, b)
+	if hide_hud_inventory() then
+		npc:use(db.actor)
+	end
+end
+
+-- Dynamic Broker dialog
+
+-- Determine if actor has valuable item:
+function condition_actor_has_valuable_item( a, b )
+
+-- 	local story_done = has_alife_info( "story_mode_disabled" ) or has_alife_info( "warlab_deactivate_generators_done" ) or false
+	local story_done = has_alife_info( "warlab_deactivate_generators_done" )
+
+	local items = {
+		["itm_pda_common"] = true,
+		["itm_pda_uncommon"] = true,
+		["itm_pda_rare"] = true,
+		--["main_story_1_quest_case"] = story_done,
+		--["main_story_2_lab_x18_documents"] = story_done,
+		--["main_story_3_lab_x16_documents"] = story_done,
+		--["main_story_4_lab_x10_documents"] = story_done,
+		--["main_story_5_lab_x8_documents"] = story_done,
+		--["main_story_6_jup_ug_documents"] = story_done,
+		--["main_story_7_mon_con_documents"] = story_done
+	}
+
+	for k,v in pairs( items ) do
+		if ( v == true and db.actor:object( k ) ) then
+			return true
+		end
+	end
+
+	return false
+
+end
+
+-- Text for if the player has an item that can be brokered:
+function text_actor_has_valuable_item( a, b )
+
+	local npc = who_is_npc( a, b )
+
+-- 	local story_done = has_alife_info( "story_mode_disabled" ) or has_alife_info( "warlab_deactivate_generators_done" ) or false
+	local story_done = has_alife_info( "warlab_deactivate_generators_done" )
+
+	local valuable = {
+		--["main_story_1_quest_case"] = story_done,
+		--["main_story_2_lab_x18_documents"] = story_done,
+		--["main_story_3_lab_x16_documents"] = story_done,
+		--["main_story_4_lab_x10_documents"] = story_done,
+		--["main_story_5_lab_x8_documents"] = story_done,
+		--["main_story_6_jup_ug_documents"] = story_done,
+		--["main_story_7_mon_con_documents"] = story_done
+	}
+
+	for k,v in pairs( valuable ) do
+		if ( v == true and db.actor:object( k ) ) then
+			return game.translate_string( "st_broker_query_valuable" )
+		end
+	end
+
+	local count = 0
+	local function itr( actor, itm )
+		local sec = itm:section( )
+		if ( sec == "itm_pda_common" or sec == "itm_pda_uncommon" or sec == "itm_pda_rare" ) then
+			count = (count + 1)
+		end
+	end
+
+	db.actor:iterate_inventory( itr, db.actor )
+
+	if ( count == 1 ) then
+		return game.translate_string( "st_broker_query_pda" )
+	end
+
+	return strformat( game.translate_string( "st_broker_query_pdas" ), count ) or game.translate_string( "st_broker_query_pda" )
+
+end
+
+-- Text for trading PDA:
+function text_trade_npc_pda(a,b)
+    local npc = who_is_npc(a, b)
+
+-- 	local story_done = has_alife_info("story_mode_disabled") or has_alife_info("warlab_deactivate_generators_done") or false
+	local story_done = has_alife_info( "warlab_deactivate_generators_done" )
+
+
+	local valuable = {
+		--["main_story_1_quest_case"] = story_done,
+		--["main_story_2_lab_x18_documents"] = story_done,
+		--["main_story_3_lab_x16_documents"] = story_done,
+		--["main_story_4_lab_x10_documents"] = story_done,
+		--["main_story_5_lab_x8_documents"] = story_done,
+		--["main_story_6_jup_ug_documents"] = story_done,
+		--["main_story_7_mon_con_documents"] = story_done
+	}
+
+	for k,v in pairs(valuable) do
+		local item = v == true and db.actor:object(k)
+		if (item) then 
+			-- xQd, don't transfer documents cu warfare trader inventory
+			local se_obj = alife_object(item:id())
+			local wf_trader
+			if not warfare.is_warfare_trader(npc) then
+				wf_trader = false
+				db.actor:transfer_item(item,npc)
+			else
+				wf_trader = true
+			end
+			news_manager.relocate_item(db.actor, "out", item:section())
+			relocate_money(npc, random_choice(10000,15000,20000,25000) , "in")
+			local name = ui_item.get_sec_name(sec)
+			if wf_trader == true then
+				alife_release(se_obj)
+			end
+			-- xQd end
+			return strformat(game.translate_string("st_broker_trade_valuable"),name)
+		end
+	end
+
+	-- Collect PDA content to determine pricing
+    local cost_per_typ = { 
+		["common"] = 1,
+		["uncommon"] = 2,
+		["rare"] = 3,
+	}
+	local cost_per_state = { 
+		["junk"] = 1,
+		["info"] = 1.5,
+		["encrypted"] = 2,
+		["kill_the_strelok"] = 15,
+	}
+
+	local pda_sell = {}
+    local function itr(actor,itm)
+		if item_device.device_npc_pda[itm:section()] then
+			local chk, pda_t = itm:section():match("(itm_pda_)([%l]+)")
+			if chk and cost_per_typ[pda_t] then
+				local id = itm:id()
+				local info = se_load_var(id, itm:name(), "info")
+				if info then
+					local state
+					if (info.state == "kill_the_strelok") then
+						state = "kill_the_strelok"
+					elseif (info.state == "encrypted") then
+						state = "encrypted"
+					else
+						local msgs = info.msg
+						for i=1,#msgs do
+							local msg = msgs[i]
+							if msg.stash or msg.route or msg.rf_freq then
+								state = "info"
+								break
+							end
+						end
+						if (not state) then
+							state = "junk"
+						end
+					end
+					pda_sell[id] = { typ = pda_t , state = state }
+				else
+					pda_sell[id] = { typ = pda_t , state = "junk" }
+				end
+				-- xQd, don't transfer pdas cu warfare trader inventory
+	
+				if not warfare.is_warfare_trader(npc) then
+					actor:transfer_item(itm,npc)
+				else
+					alife_release_id(id)
+				end
+				game_statistics.increment_statistic("pdas_delivered")
+			end
+		end
+    end
+    db.actor:iterate_inventory(itr,db.actor)
+
+    local npc_text = ""
+
+    local total_value = 0
+    local pda_bonus_coords = 0
+    local first_line
+	local count = 0
+    for id,info in pairs(pda_sell) do
+		local typ = info.typ
+		local state = info.state
+		if typ and state then
+		    local mul = (cost_per_typ[typ] * cost_per_state[state])
+			local mul2 = typ == "common" and 0.5 or typ == "uncommon" and 5 or typ == "rare" and 10
+			count = count + 1
+            total_value = total_value + (mul * math.random(350,900))
+
+            if (math.random(1,100) <= mul2) then
+                pda_bonus_coords = pda_bonus_coords + 1
+            end
+
+			if first_line then
+				npc_text = npc_text .. " " .. game.translate_string("st_drx_questlines_and_this_one") .. " "
+			end
+			
+			local trans = utils_data.collect_translations("st_broker_npc_about_pda_" .. state .. "_",true)
+			if trans then
+				npc_text = npc_text .. trans[math.random(#trans)]
+			end
+			
+			first_line = true
+		end
+    end
+
+	news_manager.relocate_item(db.actor, "out", "itm_pda_common", count)
+	
+    if (game_achievements.has_achievement("infopreneur")) then
+        total_value = total_value + math.floor(total_value / 20)
+    end
+
+	-- Round off value:
+	total_value = math.ceil( (total_value / 50) )
+	total_value = (total_value * 50)
+
+    relocate_money(npc, total_value, "in")
+
+	-- Add ending text:
+	npc_text = (npc_text .. " " .. game.translate_string( "st_drx_broker_finish_" .. math.random( 1, 3 ) ))
+
+    if (pda_bonus_coords > 0 and treasure_manager) then
+        npc_text = npc_text .. "\n\n " .. game.translate_string("st_broker_npc_about_pda_bonus_coords")
+
+        for i=1,pda_bonus_coords do
+            treasure_manager.create_random_stash()
+        end
+    end
+
+    return npc_text
+end
+
+
+
+-- Dynamic Surrender dialog
+function victim_is_bounty(a,b)
+	local npc = who_is_npc(a, b)
+	local id = npc:id()
+	for task_id,npc_id in pairs(axr_task_manager.bounties_by_id) do
+		if (id == npc_id) then
+			return true
+		end
+	end
+	return false
+end
+
+function npc_is_surrendered(a,b)
+	local npc = who_is_npc(a, b)
+	local st = db.storage[npc:id()]
+	local po = st and st.victim_surrender and st.victim_surrender < 65534 and level.object_by_id(st.victim_surrender)
+	--printf("npc_is_surrendered: surrendered to %s",st.victim_surrender)
+	if (po) then
+		return true
+	end
+	return false
+end
+
+function npc_is_not_surrendered(a,b)
+	local npc = who_is_npc(a, b)
+	local st = db.storage[npc:id()]
+	local po = st and st.victim_surrender and st.victim_surrender < 65534 and level.object_by_id(st.victim_surrender)
+	if not (po) then
+		return false
+	end
+	return true
+end
+
+function victim_surrender(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	return load_var(npc,"victim_surrender",false) == true
+end
+
+function victim_no_surrender(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	return load_var(npc,"victim_surrender",false) == false
+end
+
+function set_victim_surrendered(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	save_var(npc,"victim_surrender",true)
+end
+
+function surrender_victim_answers_bounty(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	local id = npc:id()
+
+	local prefix = "default"
+	for task_id,npc_id in pairs(axr_task_manager.bounties_by_id) do
+		if (npc_id == id) then
+			if (task_id == "esc_m_trader_task_2") then
+				prefix = "esc_m_trader"
+			elseif (task_id == "zat_b7_bandit_boss_sultan_task_1") then
+				prefix = "zat_b7_bandit_boss_sultan"
+			end
+		end
+	end
+
+	local r = math.random(1,10)
+	if (r == 1 or r == 2) and ui_pda_npc_tab.can_own_pda(npc) then
+		r = (math.random(1,100)/100)
+		local sec = "itm_pda_common"
+		if (r <= 0.10) then
+			sec = "itm_pda_rare"
+		elseif (r <= 0.5) then
+			sec = "itm_pda_uncommon"
+		end
+		relocate_item_section_to_actor(a, b, sec, 1)
+		relocate_money_to_actor(a,b,math.random(500,3000))
+		return game.translate_string("st_surrender_victim_answer_"..prefix.."_bounty_1")
+	elseif (r == 3 or r == 4) then
+		return game.translate_string("st_surrender_victim_answer_"..prefix.."_bounty_2")
+	elseif (r == 5) then
+		return game.translate_string("st_surrender_victim_answer_"..prefix.."_bounty_3")
+	elseif (r == 6 or r == 7) then
+		return game.translate_string("st_surrender_victim_answer_"..prefix.."_bounty_4")
+	elseif (r == 8 or r == 9) then
+		return game.translate_string("st_surrender_victim_answer_"..prefix.."_bounty_5")
+	end
+
+	if ((math.random(1,100)/100) < 0.5) then
+		alife_create_item("medkit_script", npc)
+		xr_wounded.unlock_medkit(npc)
+	end
+
+	return game.translate_string("st_surrender_victim_answer_5")
+end
+
+function surrender_victim_answers_1(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+
+	local r = math.random(1,5)
+
+	if (treasure_manager) and (r <= 2) then
+
+		local function itr(npc,itm)
+			if (IsWeapon(itm)) then
+				local cond = math.random(25,50)/100
+				itm:set_condition(cond)
+				npc:transfer_item(itm,db.actor)
+			end
+		end
+
+		npc:iterate_inventory(itr,npc)
+
+		if (treasure_manager) then
+			treasure_manager.create_random_stash(nil,game.translate_string("st_stash_of") .. " " .. npc:character_name(),nil,true)
+			if (game_achievements.has_achievement("silver_or_lead") and ((math.random(1,100)/100) <= 0.33)) then
+				treasure_manager.create_random_stash(nil,game.translate_string("st_stash_of") .. " " .. npc:character_name(),nil,true)
+			end
+		end
+
+		if (treasure_manager and treasure_manager.last_secret) then
+			return game.translate_string("st_surrender_victim_answer_"..math.random(3))
+		else
+			return game.translate_string("st_surrender_victim_answer_5")
+		end
+	elseif (r == 3) then
+		r = (math.random(1,100)/100)
+		local sec = "itm_pda_common"
+		if (r <= 0.10) then
+			sec = "itm_pda_rare"
+		elseif (r <= 0.5) then
+			sec = "itm_pda_uncommon"
+		end
+		relocate_item_section_to_actor(a, b, sec, 1)
+		return game.translate_string("st_surrender_victim_answer_4")
+	elseif (r == 5) then
+		alife_create_item("medkit_script", npc)
+		xr_wounded.unlock_medkit(npc)
+		return game.translate_string("st_surrender_victim_answer_5")
+	end
+	return game.translate_string("st_surrender_victim_answer_5")
+end
+
+function surrender_victim_answers_2(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	alife_create_item("medkit_script", npc)
+	xr_wounded.unlock_medkit(npc)
+	--npc:set_relation(game_object.enemy,db.actor)
+	local function itr(npc,itm)
+		if (IsWeapon(itm)) then
+			local cond = math.random(25,50)/100
+			itm:set_condition(cond)
+			npc:transfer_item(itm,db.actor)
+		end
+	end
+
+	game_statistics.increment_statistic("wounded_helped")
+
+	npc:iterate_inventory(itr,npc)
+
+	--if (math.random() <= 0.8) then
+		--npc:set_relation(game_object.neutral,db.actor)
+	--end
+
+	db.storage[npc:id()].panicked_to_actor = true
+
+	return game.translate_string("st_surrender_victim_answer_6")
+end
+
+function set_enemy(a,b)
+	local npc = dialogs.who_is_npc(a,b)
+	npc:set_relation(game_object.enemy,db.actor)
+end
+--End Alundaio
+function is_npc_in_current_smart(first_speaker, second_speaker, smart_name)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	local smart = xr_gulag.get_npc_smart(npc)
+	if not smart then return false end
+	return smart:name() == smart_name
+end
+
+function break_dialog(first_speaker, second_speaker, id)
+	first_speaker:stop_talk()
+	second_speaker:stop_talk()
+end
+
+function update_npc_dialog(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	local st = db.storage[npc:id()]
+	st.meet.meet_manager:update()
+	xr_meet.process_npc_usability(npc)
+	--xr_motivator.update_logic(npc)
+	xr_logic.try_switch_to_another_section(npc, st[st.active_scheme], db.actor)
+end
+
+function disable_talk_self(first_speaker, second_speaker)
+	first_speaker:disable_talk()
+end
+function disable_talk_victim(first_speaker, second_speaker)
+	second_speaker:disable_talk()
+end
+
+function punch(first_speaker, second_speaker)
+	--printf("KICK ASS !!!!")
+	--xr_punch.punch[first_speaker:id()] = second_speaker
+	db.storage[second_speaker:id()].punch.enabled = true
+end
+
+function get_money_then_leave(first_speaker, second_speaker)
+	db.storage[first_speaker:id()].meet.enabled = false
+	db.storage[first_speaker:id()].robber.enabled = true
+end
+
+function is_wounded(first_speaker, second_speaker)
+--	if db.storage[first_speaker:id()].wounded ~= nil and
+--		 db.storage[first_speaker:id()].wounded.wound_manager.can_use_medkit == true
+--	then
+--		return false
+--	end
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return xr_wounded.is_wounded(npc)
+end
+--[[
+function is_opp_wounded(first_speaker, second_speaker, dialog_id)
+		if db.storage[second_speaker:id()].wounded ~= nil and
+			 db.storage[second_speaker:id()].wounded.wound_manager.can_use_medkit == true
+		then
+				return false
+		end
+	return	xr_wounded.is_wounded(second_speaker)
+end
+]]--
+function is_not_wounded(first_speaker, second_speaker, dn)
+	return not is_wounded(first_speaker, second_speaker)
+end
+function actor_have_medkit(first_speaker, second_speaker)
+	local med = {"medkit","medkit_army","medkit_scientic"}
+	for k,v in pairs(med) do
+		if (first_speaker:object(v)) then
+			return true
+		end
+	end
+	return false
+end
+function actor_hasnt_medkit(first_speaker, second_speaker)
+	return actor_have_medkit(first_speaker, second_speaker) == false
+end
+function actor_have_bandage(first_speaker, second_speaker)
+	return first_speaker:object("bandage") ~= nil
+end
+function transfer_medkit(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+
+	xr_wounded.unlock_medkit(npc)
+
+	if not (npc:object("medkit_script")) then
+		alife_create_item("medkit_script", npc)
+	end
+
+	local t = {"medkit","medkit_army","medkit_scientic"}
+	for i=1,#t do
+		if (db.actor:object(t[i])) then
+			dialogs.relocate_item_section(npc,t[i],"out")
+			break
+		end
+	end
+
+	if (npc:relation(db.actor) >= game_object.enemy) then
+		npc:set_relation(game_object.neutral,db.actor)
+	else
+		npc:set_relation(game_object.friend,db.actor)
+	end
+
+	game_statistics.increment_statistic("wounded_helped")
+end
+
+function transfer_medkit_to_hip(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+
+	xr_wounded.unlock_medkit(npc)
+
+	if not (npc:object("medkit_script")) then
+		alife_create_item("medkit_script", npc)
+	end
+
+	local t = {"medkit","medkit_army","medkit_scientic"}
+	for i=1,#t do
+		if (db.actor:object(t[i])) then
+			dialogs.relocate_item_section(npc,t[i],"out")
+			break
+		end
+	end
+
+	if (npc:relation(db.actor) >= game_object.enemy) then
+		npc:set_relation(game_object.neutral,db.actor)
+	else
+		npc:set_relation(game_object.friend,db.actor)
+	end
+
+end
+
+function transfer_bandage(first_speaker, second_speaker)
+	dialogs.relocate_item_section(second_speaker, "bandage", "out")
+	second_speaker:set_relation(game_object.friend, first_speaker)
+end
+function kill_yourself(first_speaker, second_speaker)
+local npc = who_is_npc(first_speaker, second_speaker)
+	npc:kill(actor)
+end
+
+function relocate_item_section(victim, section, type, amount) -- Tronex
+	if type == "in" then
+		itms_manager.relocate_item_to_actor(db.actor, nil, section, amount)
+	elseif type == "out" then
+		itms_manager.relocate_item_from_actor(db.actor, victim, section, amount)
+	end
+end
+
+function relocate_money(victim, num, type)
+	if db.actor then
+		if type == "in" then
+			db.actor:give_money(num)
+			-- game_stats.money_quest_update (num)
+
+		elseif type == "out" then
+			if victim == nil then
+				printf("Couldn't relocate money to NULL")
+			end
+			db.actor:transfer_money(num, victim)
+			-- game_stats.money_quest_update(-num)
+		end
+		news_manager.relocate_money(db.actor, type, num)
+	end
+end
+
+--'---------------------------------------------------------------------------------
+--' DIALOG ALLOWED
+--'---------------------------------------------------------------------------------
+--function dialog_allowed(object, victim, id)
+--	if id ~= nil then
+----		printf("*DIALOGS*: dialog_allowed: %s", id)
+--	else
+----		printf("*DIALOGS*: dialog_allowed: nil")
+--	end
+--	if db.storage[victim:id()].actor_dialogs ~= nil then
+--		for k,v in pairs(db.storage[victim:id()].actor_dialogs) do
+--			if v == id then return true end
+--		end
+--	end
+--	return false
+--end
+--function dialog_not_disable(object, victim, id)
+--	if id ~= nil then
+----		printf("*DIALOGS*: dialog_disable:%s", id)
+--	else
+----		printf("*DIALOGS*: dialog_disable:nil")
+--	end
+--	if db.storage[victim:id()].actor_disable ~= nil then
+--		for k,v in pairs(db.storage[victim:id()].actor_disable) do
+--			if v == id then return false end
+--		end
+--	end
+--	return true
+--end
+
+function allow_wounded_dialog(object, victim, id)
+	if db.storage[victim:id()].wounded == nil then
+		return false
+	end
+	if db.storage[victim:id()].wounded.help_dialog == id then
+		return true
+	end
+	return false
+end
+
+--function allow_guide_dialog(object, victim, id)
+--	local section = db.storage[victim:id()].active_section
+--	printf("active_section %s", tostring(section))
+--	if section == nil then
+--		return false
+--	end
+--	if string.find(section, "conductor", 1) ~= nil then
+--		return true
+--	end
+--	return false
+--end
+
+-----------------------------------------------------------------------------------
+-- LEVELS
+-----------------------------------------------------------------------------------
+--function level_escape(first_speaker, second_speaker)
+--	return level.name() == "l01_escape"
+--end
+--
+--function level_garbage(first_speaker, second_speaker)
+--	return level.name() == "l02_garbage"
+--end
+--
+--function level_agroprom(first_speaker, second_speaker)
+--	return level.name() == "l03_agroprom_ai2" or level.name() == "l03_agroprom"
+--end
+
+
+function level_zaton(first_speaker, second_speaker)
+	return level.name() == "zaton"
+end
+
+function level_jupiter(first_speaker, second_speaker)
+	return level.name() == "jupiter"
+end
+
+function level_pripyat(first_speaker, second_speaker)
+	return level.name() == "pripyat"
+end
+
+function not_level_zaton(first_speaker, second_speaker)
+	return level.name() ~= "zaton"
+end
+
+function not_level_jupiter(first_speaker, second_speaker)
+	return level.name() ~= "jupiter"
+end
+
+function not_level_pripyat(first_speaker, second_speaker)
+	return level.name() ~= "pripyat"
+end
+
+-----------------------------------------------------------------------------------
+-- Relation functions
+-----------------------------------------------------------------------------------
+function is_friend(first_speaker, second_speaker)
+	return first_speaker:relation(second_speaker) == game_object.friend
+end
+
+function is_not_friend(first_speaker, second_speaker)
+	return not is_friend(first_speaker, second_speaker)
+end
+
+function become_friend(first_speaker, second_speaker)
+	first_speaker:set_relation(game_object.friend, second_speaker)
+end
+
+-----------------------------------------------------------------------------------
+-- Community
+-----------------------------------------------------------------------------------
+function actor_stalker(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_stalker"
+end
+
+function actor_bandit(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_bandit"
+end
+
+function actor_freedom(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_freedom"
+end
+
+function actor_dolg(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_dolg"
+end
+
+function actor_killer(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_killer"
+end
+
+function actor_army(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_army"
+end
+
+function actor_ecolog(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_ecolog"
+end
+
+function actor_csky(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_csky"
+end
+
+function actor_monolith(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_monolith"
+end
+
+function actor_renegade(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_renegade"
+end
+
+function actor_greh(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_greh"
+end
+
+function actor_isg(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_isg"
+end
+
+function actor_zombied(first_speaker, second_speaker)
+	return character_community(db.actor) == "actor_zombied"
+end
+
+
+function actor_not_stalker(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_stalker"
+end
+
+function actor_not_bandit(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_bandit"
+end
+
+function actor_not_freedom(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_freedom"
+end
+
+function actor_not_dolg(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_dolg"
+end
+
+function actor_not_killer(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_killer"
+end
+
+function actor_not_army(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_army"
+end
+
+function actor_not_ecolog(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_dolg"
+end
+
+function actor_not_csky(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_csky"
+end
+
+function actor_not_monolith(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_monolith"
+end
+
+function actor_not_renegade(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_renegade"
+end
+
+function actor_not_greh(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_greh"
+end
+
+function actor_not_isg(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_isg"
+end
+
+function actor_not_zombied(first_speaker, second_speaker)
+	return character_community(db.actor) ~= "actor_zombied"
+end
+
+
+function actor_true_stalker(first_speaker, second_speaker)
+	return get_actor_true_community() == "stalker"
+end
+
+function actor_true_bandit(first_speaker, second_speaker)
+	return get_actor_true_community() == "bandit"
+end
+
+function actor_true_freedom(first_speaker, second_speaker)
+	return get_actor_true_community() == "freedom"
+end
+
+function actor_true_dolg(first_speaker, second_speaker)
+	return get_actor_true_community() == "dolg"
+end
+
+function actor_true_killer(first_speaker, second_speaker)
+	return get_actor_true_community() == "killer"
+end
+
+function actor_true_army(first_speaker, second_speaker)
+	return get_actor_true_community() == "army"
+end
+
+function actor_true_ecolog(first_speaker, second_speaker)
+	return get_actor_true_community() == "ecolog"
+end
+
+function actor_true_csky(first_speaker, second_speaker)
+	return get_actor_true_community() == "csky"
+end
+
+function actor_true_monolith(first_speaker, second_speaker)
+	return get_actor_true_community() == "monolith"
+end
+
+function actor_true_renegade(first_speaker, second_speaker)
+	return get_actor_true_community() == "renegade"
+end
+
+function actor_true_greh(first_speaker, second_speaker)
+	return get_actor_true_community() == "greh"
+end
+
+function actor_true_isg(first_speaker, second_speaker)
+	return get_actor_true_community() == "isg"
+end
+
+
+function actor_not_true_stalker(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "stalker"
+end
+
+function actor_not_true_bandit(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "bandit"
+end
+
+function actor_not_true_freedom(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "freedom"
+end
+
+function actor_not_true_dolg(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "dolg"
+end
+
+function actor_not_true_killer(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "killer"
+end
+
+function actor_not_true_army(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "army"
+end
+
+function actor_not_true_ecolog(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "ecolog"
+end
+
+function actor_not_true_csky(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "csky"
+end
+
+function actor_not_true_monolith(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "monolith"
+end
+
+function actor_not_true_renegade(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "renegade"
+end
+
+function actor_not_true_greh(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "greh"
+end
+
+function actor_not_true_isg(first_speaker, second_speaker)
+	return get_actor_true_community() ~= "isg"
+end
+
+
+function npc_stalker(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "stalker"
+end
+
+function npc_bandit(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "bandit"
+end
+
+function npc_freedom(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "freedom"
+end
+
+function npc_dolg(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "dolg"
+end
+
+function npc_killer(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "killer"
+end
+
+function npc_army(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "army"
+end
+
+function npc_ecolog(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "ecolog"
+end
+
+function npc_csky(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "csky"
+end
+
+function npc_monolith(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "monolith"
+end
+
+function npc_renegade(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "renegade"
+end
+
+function npc_greh(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "greh"
+end
+
+function npc_isg(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return character_community(npc) == "isg"
+end
+
+-----------------------------------------------------------------------------------
+-- Goodwill
+-----------------------------------------------------------------------------------
+function is_actor_trustworthy(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	local sec = npc:section()
+	
+	local comm = sim_offline_combat.story_id_communities[sec] or character_community(npc)
+	if (comm == "trader") then comm = "stalker" end
+	
+	local goodwill = relation_registry.community_goodwill(comm, AC_ID)
+	return goodwill > goodwill_trust_limit
+end
+
+function is_actor_not_trustworthy(first_speaker, second_speaker)
+	return (not is_actor_trustworthy(first_speaker, second_speaker))
+end
+
+-----------------------------------------------------------------------------------
+-- Rank
+-----------------------------------------------------------------------------------
+function is_actor_experienced(first_speaker, second_speaker)
+	local rank = ranks.get_obj_rank_name(db.actor)
+	if (rank == "veteran" or rank == "expert" or rank == "master" or rank == "legend") then
+		return true
+    end
+	return false
+end
+
+function is_actor_reliable(first_speaker, second_speaker)
+	return (not is_actor_noob(first_speaker, second_speaker))
+end
+
+function is_actor_noob(first_speaker, second_speaker)
+	local rank = ranks.get_obj_rank_name(db.actor)
+	if (rank == "novice" or rank == "trainee") then
+		return true
+    end
+	return false
+end
+
+-----------------------------------------------------------------------------------
+-- Money functions
+-----------------------------------------------------------------------------------
+function has_2000_money(first_speaker, second_speaker)
+	return first_speaker:money() >= 2000
+end
+
+-----------------------------------------------------------------------------------
+-- TRADE
+-----------------------------------------------------------------------------------
+--' Инициализация торговли
+function trade_init(seller, buyer)
+	db.storage[seller:id()].meet.begin_wait_to_see.begin = time_global()/1000
+	xr_position.setPosition(db.storage[seller:id()].meet.Seller,
+							db.storage[seller:id()].meet.Seller:level_vertex_id())
+	db.storage[seller:id()].meet.Buyer = buyer
+end
+
+function want_trade(seller, buyer)
+	if seller:relation(buyer) == game_object.friend or
+		seller:relation(buyer) == game_object.neutral
+	then
+		return true
+	else
+		return false
+	end
+end
+
+function dont_want_trade(seller, buyer)
+	return not want_trade(seller,buyer)
+end
+
+function relocate_item_section_to_actor(first_speaker, second_speaker, section, amount) -- Tronex
+	local npc = who_is_npc(first_speaker, second_speaker)
+	itms_manager.relocate_item_to_actor(db.actor, npc, section, amount)
+end
+
+function relocate_money_to_actor(first_speaker, second_speaker, num)
+	db.actor:give_money(num)
+	-- game_stats.money_quest_update (num)
+	news_manager.relocate_money(db.actor, "in", num)
+end
+
+function relocate_money_from_actor(first_speaker, second_speaker, num)
+	local victim = who_is_npc(first_speaker, second_speaker)
+	if victim == nil then
+		printf("Couldn't relocate money to NULL")
+	end
+	db.actor:transfer_money(num, victim)
+	-- game_stats.money_quest_update(-num)
+	news_manager.relocate_money(db.actor, "out", num)
+end
+
+--[[ Old one
+function relocate_item_section_from_actor(first_speaker, second_speaker, section)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	db.actor:transfer_item(db.actor:object(section), npc)
+	news_manager.relocate_item(db.actor, "out", section)
+end
+]]--
+
+function who_is_actor(first_speaker, second_speaker)
+	local npc = second_speaker
+	if AC_ID ~= npc:id() then
+		npc	= first_speaker
+	end
+	return npc
+end
+
+function relocate_item_section_from_actor(first_speaker, second_speaker, section, amount) -- Tronex
+	local npc = who_is_npc(first_speaker, second_speaker)
+	itms_manager.relocate_item_from_actor(db.actor, npc, section, amount)
+end
+
+function actor_has_item(first_speaker, second_speaker, section)
+	return db.actor:object(section) ~= nil
+end
+
+function npc_has_item(first_speaker, second_speaker, section)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	return npc:object(section) ~= nil
+end
+
+function who_is_npc(first_speaker, second_speaker)
+	return first_speaker:id() == AC_ID and second_speaker or first_speaker
+end
+
+--------------------------------------------------------------------------------
+function transfer_any_pistol_from_actor(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_pistol, npc)
+	if(db.actor.pistol~=nil) then
+			db.actor:transfer_item(db.actor:object(db.actor.pistol), npc)
+		news_manager.relocate_item(db.actor, "out", db.actor.pistol)
+		db.actor.pistol = nil
+	end
+end
+
+function is_pistol(npc, item)
+	local section = item:section()
+	if(section=="wpn_beretta")
+	or(section=="wpn_colt1911")
+	or(section=="wpn_desert_eagle")
+	or(section=="wpn_fort")
+	or(section=="wpn_hpsa")
+	or(section=="wpn_pb")
+	or(section=="wpn_pm")
+	or(section=="wpn_usp")
+	or(section=="wpn_walther") then
+		db.actor.pistol = section
+	end
+end
+
+function have_actor_any_pistol(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_pistol, npc)
+	if(db.actor.pistol~=nil) then
+		return true
+	else
+		return false
+	end
+end
+
+--------------------------------------------------------------------------------
+function transfer_any_gun_from_actor(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_gun, npc)
+	if(db.actor.gun~=nil) then
+			db.actor:transfer_item(db.actor:object(db.actor.gun), npc)
+		news_manager.relocate_item(db.actor, "out", db.actor.gun)
+		db.actor.gun = nil
+	end
+end
+
+function is_gun(npc, item)
+	local section = item:section()
+	if(section=="wpn_abakan")
+	or(section=="wpn_ak74")
+	or(section=="wpn_ak74u")
+	or(section=="wpn_groza")
+	or(section=="wpn_sig550")
+	or(section=="wpn_vintorez") then
+		db.actor.gun = section
+	end
+end
+
+function have_actor_any_gun(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_gun, npc)
+	if(db.actor.gun~=nil) then
+		return true
+	else
+		return false
+	end
+end
+
+--------------------------------------------------------------------------------
+function transfer_any_shootgun_from_actor(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_shootgun, npc)
+	if(db.actor.shootgun~=nil) then
+			db.actor:transfer_item(db.actor:object(db.actor.shootgun), npc)
+		news_manager.relocate_item(db.actor, "out", db.actor.shootgun)
+		db.actor.shootgun = nil
+	end
+end
+
+function is_shootgun(npc, item)
+	local section = item:section()
+	if(section=="wpn_bm16")
+	or(section=="wpn_toz34")
+	or(section=="wpn_wincheaster1300")
+	or(section=="wpn_spas12") then
+		db.actor.shootgun = section
+	end
+end
+
+function have_actor_any_shootgun(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+		db.actor:iterate_inventory(is_shootgun, npc)
+	if(db.actor.shootgun~=nil) then
+		return true
+	else
+		return false
+	end
+end
+
+-----------------------------------------------------------------------------------
+-- Weapons
+-----------------------------------------------------------------------------------
+function give_suitable_ammo(first_speaker, second_speaker)
+	local wpns = {}
+	local wpn_1 = db.actor:item_in_slot(2)
+	if wpn_1 and IsWeapon(wpn_1) then
+		wpns[#wpns + 1] = wpn_1:section()
+	end
+	
+	local wpn_2 = db.actor:item_in_slot(3)
+	if wpn_2 and IsWeapon(wpn_2) then
+		wpns[#wpns + 1] = wpn_2:section()
+	end
+	
+	for i=1,#wpns do
+		local section = wpns[i]
+		local ammo = parse_list(ini_sys,section,"ammo_class")
+		if ammo and #ammo > 0 then
+			local ammo_sec = ammo[1]
+			local box_size = ini_sys:r_u32(ammo_sec, "box_size")
+			alife_create_item(ammo_sec, db.actor, { ammo = box_size })
+			
+			news_manager.relocate_item(db.actor, "in", ammo_sec, box_size)
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+--			ALIFE SUPPORT
+--------------------------------------------------------------------------------
+
+function disable_ui(first_speaker, second_speaker)
+	xr_effects.disable_ui(first_speaker, second_speaker)
+end
+
+function disable_ui_only(first_speaker, second_speaker)
+	xr_effects.disable_ui_only(first_speaker, second_speaker)
+end
+
+function is_surge_running(first_speaker, second_speaker)
+	return xr_conditions.surge_started()
+end
+
+function is_surge_not_running(first_speaker, second_speaker)
+	return not xr_conditions.surge_started()
+end
+
+---------------------
+function quest_dialog_heli_precond(first_speaker, second_speaker)
+	if (has_alife_info("jup_b9_heli_1_searched") and
+				has_alife_info("zat_b100_heli_2_searched") and
+				has_alife_info("zat_b28_heli_3_searched") and
+				has_alife_info("jup_b8_heli_4_searched") and
+				has_alife_info("zat_b101_heli_5_searched")) or
+				has_alife_info("pri_b305_actor_wondered_done") then
+			return false
+	end
+
+	return true
+end
+
+function quest_dialog_military_precond(first_speaker, second_speaker)
+	if has_alife_info("zat_b28_heli_3_searched") or has_alife_info("jup_b9_blackbox_decrypted") then
+		if not (has_alife_info("zat_b28_heli_3_searched") and has_alife_info("jup_b9_blackbox_decrypted")) then
+			return true
+		end
+	end
+	return false
+end
+
+function quest_dialog_squad_precond(first_speaker, second_speaker)
+	return not (has_alife_info("jup_b218_monolith_hired") and has_alife_info("jup_b218_soldier_hired") and has_alife_info("jup_a10_vano_agree_go_und"))
+end
+
+function quest_dialog_toolkits_precond(first_speaker, second_speaker)
+	if has_alife_info("zat_a2_mechanic_toolkit_search") and not has_alife_info("zat_b3_task_end") then
+		return true
+	elseif has_alife_info("jup_b217_tech_instruments_start") and not has_alife_info("jup_b217_task_end") then
+		return true
+	end
+	return false
+end
+
+
+function squad_not_in_smart_b101(first_speaker, second_speaker)
+	local smart = "zat_b101"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b103(first_speaker, second_speaker)
+	local smart = "zat_b103"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b104(first_speaker, second_speaker)
+	local smart = "zat_b104"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b213(first_speaker, second_speaker)
+	local smart = "jup_b213"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b214(first_speaker, second_speaker)
+	local smart = "jup_b214"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b304(first_speaker, second_speaker)
+	local smart = "pri_b304_monsters_smart_terrain"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b303(first_speaker, second_speaker)
+	local smart = "pri_b303"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b40(first_speaker, second_speaker)
+	local smart = "zat_b40_smart_terrain"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b18(first_speaker, second_speaker)
+	local smart = "zat_b18"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b6(first_speaker, second_speaker)
+	local smart = "jup_b41"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b205(first_speaker, second_speaker)
+	local smart = "jup_b205_smart_terrain"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_not_in_smart_b47(first_speaker, second_speaker)
+	local smart = "jup_b47"
+	return not is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_in_smart_zat_base(first_speaker, second_speaker)
+	local smart = "zat_stalker_base_smart"
+	return is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function squad_in_smart_jup_b25(first_speaker, second_speaker)
+	local smart = "jup_a6"
+	return is_npc_in_current_smart(first_speaker, second_speaker, smart)
+end
+
+function spartak_is_alive(first_speaker, second_speaker)
+	return xr_conditions.is_alive(nil,nil,{"zat_b7_stalker_victim_1"})
+end
+
+function tesak_is_alive(first_speaker, second_speaker)
+	return xr_conditions.is_alive(nil,nil,{"zat_b103_lost_merc_leader"})
+end
+
+function gonta_is_alive(first_speaker, second_speaker)
+	return xr_conditions.is_alive(nil,nil,{"zat_b103_lost_merc_leader"})
+end
+
+function mityay_is_alive(first_speaker, second_speaker)
+	return xr_conditions.is_alive(nil,nil,{"jup_a12_stalker_assaulter"})
+end
+
+function dolg_can_work_for_sci(first_speaker, second_speaker)
+	return not (has_alife_info("jup_a6_freedom_leader_bunker_guards_work") or has_alife_info("jup_a6_freedom_leader_bunker_scan_work"))
+end
+
+function dolg_can_not_work_for_sci(first_speaker, second_speaker)
+	return has_alife_info("jup_a6_freedom_leader_bunker_guards_work") or has_alife_info("jup_a6_freedom_leader_bunker_scan_work")
+end
+
+function freedom_can_work_for_sci(first_speaker, second_speaker)
+	return not (has_alife_info("jup_a6_duty_leader_bunker_guards_work") or has_alife_info("jup_a6_duty_leader_bunker_scan_work"))
+end
+
+function freedom_can_not_work_for_sci(first_speaker, second_speaker)
+	return has_alife_info("jup_a6_duty_leader_bunker_guards_work") or has_alife_info("jup_a6_duty_leader_bunker_scan_work")
+end
+
+function monolith_leader_is_alive(first_speaker, second_speaker)
+	if not (has_alife_info("jup_b4_monolith_squad_in_freedom") or has_alife_info("jup_b4_monolith_squad_in_duty")) then
+		return xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_monolith_skin"})
+	end
+
+	if has_alife_info("jup_b4_monolith_squad_in_freedom") then
+		return xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_freedom_skin"})
+	elseif has_alife_info("jup_b4_monolith_squad_in_duty") then
+		return xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_duty_skin"})
+	end
+
+	return false
+end
+
+function monolith_leader_dead_or_hired(first_speaker, second_speaker)
+	if has_alife_info("jup_b218_soldier_hired") then
+		return true
+	end
+
+	if not (has_alife_info("jup_b4_monolith_squad_in_freedom") or has_alife_info("jup_b4_monolith_squad_in_duty")) then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_monolith_skin"})
+	end
+
+	if has_alife_info("jup_b4_monolith_squad_in_freedom") then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_freedom_skin"})
+	elseif has_alife_info("jup_b4_monolith_squad_in_duty") then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_duty_skin"})
+	end
+
+	return true
+end
+
+function monolith_leader_dead_or_dolg(first_speaker, second_speaker)
+	if has_alife_info("jup_b218_soldier_hired") then
+		return true
+	end
+
+	if not (has_alife_info("jup_b4_monolith_squad_in_freedom") or has_alife_info("jup_b4_monolith_squad_in_duty")) then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_monolith_skin"})
+	end
+
+	if has_alife_info("jup_b4_monolith_squad_in_freedom") then
+		return true
+	elseif has_alife_info("jup_b4_monolith_squad_in_duty") then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_duty_skin"})
+	end
+
+	return true
+end
+
+function monolith_leader_dead_or_freedom(first_speaker, second_speaker)
+	if has_alife_info("jup_b218_soldier_hired") then
+		return true
+	end
+
+	if not (has_alife_info("jup_b4_monolith_squad_in_freedom") or has_alife_info("jup_b4_monolith_squad_in_duty")) then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_monolith_skin"})
+	end
+
+	if has_alife_info("jup_b4_monolith_squad_in_freedom") then
+		return not xr_conditions.is_alive(nil,nil,{"jup_b4_monolith_squad_leader_freedom_skin"})
+	elseif has_alife_info("jup_b4_monolith_squad_in_duty") then
+		return true
+	end
+
+	return true
+end
+
+-- Medic support
+function medic_magic_potion(first_speaker, second_speaker)
+	db.actor.health = 1
+	db.actor.power = 1
+-- com	db.actor.radiation = 0
+	db.actor.bleeding = 1
+end
+
+function medic_rad_potion(first_speaker, second_speaker)
+	db.actor.radiation = 0
+end
+
+function health_care_actor_has_money(first_speaker, second_speaker)
+	return db.actor:money() >= 1850
+end
+
+function health_care_actor_has_rad_money(first_speaker, second_speaker)
+	return db.actor:money() >= 1480
+end
+
+function health_care_actor_hasnt_money(first_speaker, second_speaker)
+	return not health_care_actor_has_money(first_speaker, second_speaker)
+end
+
+function health_care_actor_hasnt_rad_money(first_speaker, second_speaker)
+	return not health_care_actor_has_rad_money(first_speaker, second_speaker)
+end
+
+function health_care_actor_transfer_money(first_speaker, second_speaker)
+	dialogs.relocate_money_from_actor(first_speaker, second_speaker, 1850)
+end
+
+function health_care_actor_transfer_rad_money(first_speaker, second_speaker)
+	dialogs.relocate_money_from_actor(first_speaker, second_speaker, 1480)
+end
+
+function give_hip_medic_potion(first_speaker, second_speaker)
+	local npc = who_is_npc(first_speaker, second_speaker)
+	npc.health = 1
+	npc.power = 1
+	npc.radiation = 0
+	npc.bleeding = 1
+end
+
+function actor_needs_bless(first_speaker, second_speaker)
+	if db.actor.health < 1 or
+			db.actor.radiation > 0 or
+			db.actor.bleeding > 0 then
+		return true
+	end
+
+	return false
+end
+
+function actor_needs_health(first_speaker, second_speaker)
+	if (db.actor.health < 1) and (db.actor:money() >= 1850) then
+		return true
+	end
+	return false
+end
+
+function actor_needs_rad_health(first_speaker, second_speaker)
+	if (db.actor.radiation > 0) and (db.actor:money() >= 1480) then
+		return true
+	end
+	return false
+end
+
+function actor_is_damn_healthy(first_speaker, second_speaker)
+	return not actor_needs_bless(first_speaker, second_speaker)
+end
+
+function actor_needs_rad_bless(first_speaker, second_speaker)
+	if db.actor.radiation > 0 or
+			db.actor.bleeding >= 0 then
+		return true
+	end
+
+	return false
+end
+
+function actor_wants_rad_bless(first_speaker, second_speaker)
+	if db.actor.radiation > 0 and db.actor:money() >= 3500 then
+		return true
+	end
+
+	return false
+end
+
+function actor_must_rad_bless(first_speaker, second_speaker)
+	if db.actor.radiation > 0 and db.actor:money() >= 500 and db.actor:money() < 3500 then
+		return true
+	end
+
+	return false
+end
+
+function actor_is_damn_healthy(first_speaker, second_speaker)
+	return not actor_needs_bless(first_speaker, second_speaker)
+end
+
+function leave_zone_save(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_zone_to_reality"})
+end
+
+function save_uni_travel_zat_to_jup(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_zat_to_jup"})
+end
+
+function save_uni_travel_zat_to_pri(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_zat_to_pri"})
+end
+
+function save_uni_travel_jup_to_zat(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_jup_to_zat"})
+end
+
+function save_uni_travel_jup_to_pri(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_jup_to_pri"})
+end
+
+function save_uni_travel_pri_to_zat(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_pri_to_zat"})
+end
+
+function save_uni_travel_pri_to_jup(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_uni_travel_pri_to_jup"})
+end
+
+function save_jup_b218_travel_jup_to_pas(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_jup_b218_travel_jup_to_pas"})
+end
+
+function save_pri_a17_hospital_start(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_pri_a17_hospital_start"})
+end
+
+function save_jup_a10_gonna_return_debt(first_speaker, second_speaker)
+	if has_alife_info("jup_a10_vano_give_task") and not has_alife_info("jup_a10_avtosave") and not has_alife_info("jup_b218_gather_squad_complete") then
+		xr_effects.scenario_autosave(db.actor,nil,{"st_save_jup_a10_gonna_return_debt"})
+		db.actor:give_info_portion("jup_a10_avtosave")
+	end
+end
+
+function save_jup_b6_arrived_to_fen(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_jup_b6_arrived_to_fen"})
+end
+
+function save_jup_b6_arrived_to_ash_heap(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_jup_b6_arrived_to_ash_heap"})
+end
+
+function save_jup_b19_arrived_to_kopachy(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_jup_b19_arrived_to_kopachy"})
+end
+
+function save_zat_b106_arrived_to_chimera_lair(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_zat_b106_arrived_to_chimera_lair"})
+end
+
+function save_zat_b5_met_with_others(first_speaker, second_speaker)
+	xr_effects.scenario_autosave(db.actor,nil,{"st_save_zat_b5_met_with_others"})
+end
+
+function can_do_alun_riddle_quest(first_speaker, second_speaker)
+	return has_alife_info("alun_riddle_begin") ~= true
+end
+
+
+-----------------------------------------------------------------------------------
+-- Medic general dialog
+-----------------------------------------------------------------------------------
+function is_actor_not_healthy(first_speaker, second_speaker)
+	if (db.actor.health < 1 or db.actor.bleeding > 0 or db.actor.radiation > 0) then
+		return true
+	end
+	return false
+end
+function is_actor_healthy(first_speaker, second_speaker)
+	return (not is_actor_not_healthy(first_speaker, second_speaker))
+end
+
+function is_actor_injured(first_speaker, second_speaker)
+	if (db.actor.health < 1 or db.actor.bleeding > 0)
+	and (db.actor:money() >= 1850)
+	then
+		return true
+	end
+	return false
+end
+function is_actor_irradiated(first_speaker, second_speaker)
+	if (db.actor.radiation > 0)
+	and (db.actor:money() >= 1480)
+	then
+		return true
+	end
+	return false
+end
+function is_actor_injured_irradiated(first_speaker, second_speaker)
+	if (db.actor.health < 1 or db.actor.bleeding > 0) and (db.actor.radiation > 0)
+	and (db.actor:money() >= 3350)
+	then
+		return true
+	end
+	return false
+end
+
+function heal_actor_injury(first_speaker, second_speaker)
+	relocate_money_from_actor (first_speaker, second_speaker, 1850)
+	db.actor.health = 1
+	db.actor.power = 1
+	db.actor.bleeding = 1
+end
+function heal_actor_radiation(first_speaker, second_speaker)
+	relocate_money_from_actor (first_speaker, second_speaker, 1480)
+	db.actor.radiation = 0
+end
+function heal_actor_injury_radiation(first_speaker, second_speaker)
+	relocate_money_from_actor (first_speaker, second_speaker, 3350)
+	db.actor.health = 1
+	db.actor.power = 1
+	db.actor.radiation = 0
+	db.actor.bleeding = 1
+end
+
+function st_dm_medic_general_text_1(first_speaker, second_speaker)
+	local str_0 = "st_dm_medic_general_text_1_0"
+	local str_r = "st_dm_medic_general_text_1_" .. math.random(1,3)
+	local str = game.translate_string(str_r) .. " " .. game.translate_string(str_0)
+	return str
+end
+function st_dm_medic_general_text_10(first_speaker, second_speaker)
+	local str_0 = "st_dm_medic_general_text_10_0"
+	local str_r = "st_dm_medic_general_text_10_" .. math.random(1,4)
+	local str = game.translate_string(str_r) .. " " .. game.translate_string(str_0)
+	return str
+end
+
+
+-----------------------------------------------------------------------------------
+-- Trade important documents
+-----------------------------------------------------------------------------------
+local important_docs = {
+}
+
+local important_docs_warfare_names = {
+	["stalker"] = "bar_visitors_barman_stalker_trader",
+	["bandit"] = "zat_b7_bandit_boss_sultan",
+	["csky"] = "mar_smart_terrain_base_stalker_leader_marsh",
+	["dolg"] = "bar_dolg_leader",
+	["army"] = "agr_smart_terrain_1_6_near_2_military_colonel_kovalski",
+	["killer"] = "cit_killers_merc_trader_stalker",
+	["ecolog"] = "yan_stalker_sakharov",
+	["freedom"] = "mil_smart_terrain_7_7_freedom_leader_stalker",
+}
+
+local inv_important_docs = {}
+local inv_important_docs_money = 0
+function actor_has_important_documents(a,b)
+	-- reset
+	empty_table(inv_important_docs)
+	inv_important_docs_money = 0
+	
+	local function itr(_,obj)
+		local sec = obj:section()
+		if important_docs[sec] then
+			inv_important_docs[#inv_important_docs + 1] = sec
+		end
+	end
+	db.actor:iterate_inventory(itr, nil)
+	
+	return (#inv_important_docs > 0)
+end
+
+function st_trade_important_documents(a,b,typ,txt)
+	local npc = who_is_npc(a, b)
+	local npc_name
+	if _G.WARFARE then
+		local se_obj = alife_object(npc:id())
+		local comm = se_obj:community()
+		npc_name = important_docs_warfare_names[comm]
+		if not npc_name then
+			npc_name = npc:section()
+			if npc_name == "m_trader" then
+				npc_name = npc:name()
+			end
+		end
+	else
+		npc_name = npc:section()
+		if npc_name == "m_trader" then
+			npc_name = npc:name()
+		end
+	end
+	local str = game.translate_string("st_trade_important_documents_".. typ .. "_" .. npc_name)
+	str = strformat(str,txt)
+	return str
+end
+
+function st_trade_important_documents_ask(a,b)
+	inv_important_docs_money = 0
+	for i=1,#inv_important_docs do
+		inv_important_docs_money = inv_important_docs_money + important_docs[inv_important_docs[i]]
+	end
+	
+	-- Economy factor
+	local eco_type = game_difficulties.get_eco_factor("type")
+	local factor = ((eco_type == 3) and 0.5) or ((eco_type == 2) and 0.75) or 1
+	inv_important_docs_money = inv_important_docs_money * factor
+	
+	-- Randomizer
+	local delta = inv_important_docs_money * 0.1
+	inv_important_docs_money = math.ceil(math.random(inv_important_docs_money - delta , inv_important_docs_money + delta ))
+	
+	return st_trade_important_documents(a,b,"ask",inv_important_docs_money)
+end
+
+function st_trade_important_documents_answer(a,b)
+	return st_trade_important_documents(a,b,"answer","")
+end
+
+function trade_important_documents_reward(a,b)
+	local sweets_1 = {
+		"af_aac",
+		"af_iam",
+		"af_plates",
+		"af_camelbak",
+		"af_surge_up",
+		"af_frames_up",
+		"af_grid_up",
+		"af_grid",
+	}
+	local sweets_2 = {
+		"stimpack",
+		"medkit_army",
+		"medkit",
+		"drug_psy_blockade",
+	}
+	
+	for i=1,#inv_important_docs do
+		dialogs.relocate_item_section(db.actor, inv_important_docs[i], "out")
+		local obj = db.actor:object(inv_important_docs[i])
+		if obj then
+			alife_release_id(obj:id())
+		end
+	end
+	dialogs.relocate_money(db.actor, inv_important_docs_money, "in")
+	dialogs.relocate_item_section(db.actor, sweets_1[math.random(#sweets_1)], "in", 1)
+	dialogs.relocate_item_section(db.actor, sweets_2[math.random(#sweets_2)], "in", math.random(2,3))
+end
+
+
+-----------------------------------------------------------------------------------
+-- Trade / Repair init
+-----------------------------------------------------------------------------------
+function is_trade_init_accept(a,b)
+	local npc = who_is_npc(a, b)
+	local id = npc:id()
+	
+	local npc_items = death_manager.get_items_by_npc(id)
+	return (npc_items ~= false)
+end
+function is_trade_accept(a,b)
+	local npc = who_is_npc(a, b)
+	local id = npc:id()
+	
+	local npc_items = death_manager.get_items_by_npc(id)
+	
+	-- first-time trade request, decide if NPC wants to trade
+	local init_items = nil
+	if (npc_items == nil) then
+		init_items = (math.random(100) <= 60) and true or false
+	end
+	
+	-- if npc agrees, spawn items in his inventory
+	if (init_items == true) then
+		local npc_comm = character_community(npc)
+		local npc_rank = ranks.get_obj_rank_name(npc)
+		death_manager.create_item_list(npc, npc_comm, npc_rank, false, true)
+	
+	-- if npc disagrees, mark him
+	elseif (init_items == false) then
+		death_manager.set_items_by_npc(id,false)
+	end
+	
+	return ((npc_items or init_items) and true or false)
+end
+function is_not_trade_accept(a,b)
+	local npc = who_is_npc(a, b)
+	local id = npc:id()
+	
+	local npc_items = death_manager.get_items_by_npc(id)
+	return (npc_items == false)
+end
+
+function st_stalker_trade_dialog_reply(a,b)
+	local str = game.translate_string("st_stalker_trade_dialog_reply_" .. math.random(1,3))
+	return str
+end
+
+function st_stalker_trade_dialog_reply_no(a,b)
+	local str = game.translate_string("st_stalker_trade_dialog_reply_no_" .. math.random(1,2))
+	return str
+end
+
+function st_trader_dialog_reply(a,b)
+	local str = game.translate_string("st_trader_dialog_reply_" .. math.random(1,3))
+	return str
+end
+
+function st_mechanic_dialog_reply(a,b)
+	local str = game.translate_string("st_mechanic_dialog_reply_" .. math.random(1,3))
+	return str
+end
+
+function st_medic_dialog_reply(a,b)
+	local str = game.translate_string("st_medic_dialog_reply_" .. math.random(1,3))
+	return str
+end
+
+function st_bartender_dialog_reply(a,b)
+	local str = game.translate_string("st_bartender_dialog_reply_" .. math.random(1,3))
+	return str
+end
+
+
+-----------------------------------------------------------------------------------
+-- Questions about NPC life style
+-----------------------------------------------------------------------------------
+local lifestyle_asked_already = {} -- dialog is available 2 times only for an npc: when asked and get answer, and when npc has enough
+local lifestyle_id -- stores latest npc with this dialog, it will be safe because of the procondition
+local lifestyle_tbl = {
+	["esc_m_trader"] = "esc_m_trader",
+	["bar_dolg_leader"] = "bar_dolg_leader",
+	["mil_smart_terrain_7_7_freedom_leader_stalker"] = "mil_smart_terrain_7_7_freedom_leader_stalker",
+	["yan_stalker_sakharov"] = "yan_stalker_sakharov",
+	["jup_b6_scientist_nuclear_physicist"] = "yan_stalker_sakharov",
+	["hunter_gar_trader"] = "hunter_gar_trader",
+	["jup_b220_trapper"] = "jup_b220_trapper",
+}
+
+function lifestyle_first_time(a,b)
+	local npc = who_is_npc(a, b)
+	local name = npc and (npc:section() ~= "m_trader") and npc:section() or npc:name()
+	lifestyle_id = npc:id()
+	--printf("- lifestyle_first_time | NPC: %s - id: %s", name, lifestyle_id)
+	-- if npc is asked twice, no dialog
+	if name and (lifestyle_asked_already[name] == true) then
+		return false
+	end
+	return true
+end
+function st_lifestyle_ask(a,b)
+	local npc = lifestyle_id and db.storage[lifestyle_id] and db.storage[lifestyle_id].object
+	local name = npc and (npc:section() ~= "m_trader") and npc:section() or npc:name()
+	local prof = name and lifestyle_tbl[name]
+	if prof then
+		return game.translate_string("st_" .. prof .. "_life_ask")
+	end
+	return game.translate_string("st_esc_m_trader_life_ask")
+end
+function st_lifestyle_answer(a,b)
+	local npc = lifestyle_id and db.storage[lifestyle_id] and db.storage[lifestyle_id].object
+	local name = npc and (npc:section() ~= "m_trader") and npc:section() or npc:name()
+	local prof = name and lifestyle_tbl[name]
+	
+	-- if npc is asked once, second answer is enough
+	if prof and (lifestyle_asked_already[name] == false) then
+		lifestyle_asked_already[name] = true
+		return game.translate_string("st_" .. prof .. "_life_end")
+	end
+	lifestyle_asked_already[name] = false
+	
+	-- if npc never asked, give proper answer
+	local tbl = prof and utils_data.collect_translations("st_" .. prof .. "_life_",true)
+	if (not tbl) then
+		lifestyle_asked_already[name] = true
+		return game.translate_string("st_esc_m_trader_life_end")
+	end
+	return tbl[math.random(#tbl)]
+end

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/sim_squad_scripted.script
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/sim_squad_scripted.script
@@ -1042,6 +1042,7 @@ function sim_squad_scripted:on_unregister()
 	cse_alife_online_offline_group.on_unregister(self)
 end
 
+-- warning: the one inside warfare_options.script is used regardless of if warfare mode is on or not
 function sim_squad_scripted:check_online_status()
 	local b = nil
 	if (get_object_story_id(self.id)) then 

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_mm_faction_select.script
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_mm_faction_select.script
@@ -1276,7 +1276,7 @@ function UINewGame:LoadLoadout (rand)
 	end
 	
 	while true do
-		local idx = random_key_table( self.CC["loadout"].cell )
+		local idx = is_not_empty(self.CC["loadout"].cell) and random_key_table( self.CC["loadout"].cell )
 		if (not idx) then
 			return
 		end

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_options.script
@@ -429,9 +429,9 @@ options = {
 	{ id= "general"      	,sh=true ,gr={
 		{ id= "slide_alife"		,type= "slide"	  ,link= "ui_options_slider_alife"	 ,text= "ui_mm_title_alife"		,size= {512,50}		},
 
-		{ id= "alife_mutant_pop"  		,type= "list"    ,val= 2  ,def= 0.75 	 ,content= {{0.25} , {0.5} , {0.75} , {1}}		,no_str= true  },
-		{ id= "alife_stalker_pop"  		,type= "list"    ,val= 2  ,def= 0.5 	 ,content= {{0.25} , {0.5} , {0.75} , {1}}		,no_str= true  },
-		{ id= "offline_combat"  		,type= "list"    ,val= 0  ,def= "full" 	 ,content= {{"full","full"} , {"on_smarts_only","on_smarts_only"}, {"off","off"}} },
+		{ id= "alife_mutant_pop"  		,type= "list"    ,val= 2  ,def= 1.5 	 ,content= {{0.25} , {0.5} , {0.75} , {1}, {1.5}, {2}, {3}}		,no_str= true  },
+		{ id= "alife_stalker_pop"  		,type= "list"    ,val= 2  ,def= 1 	 ,content= {{0.25} , {0.5} , {0.75} , {1}, {1.5}, {2}}		,no_str= true  },
+		{ id= "offline_combat"  		,type= "list"    ,val= 0  ,def= "full" 	 ,content= {{"full","full"}, {"on_smarts_only","on_smarts_only"}, {"off","off"}} },
 		{ id= "excl_dist"  				,type= "list"    ,val= 2  ,def= 75 	 	 ,content= {{0} , {25} , {50} , {75} , {100}}	,no_str= true  },
 		{ id= "dynamic_anomalies"        ,type= "check"    ,val= 1	,def= true	 },
 		{ id= "dynamic_relations"        ,type= "check"    ,val= 1	,def= false	 },
@@ -1221,8 +1221,8 @@ function UIOptions:InitControls()
 	self.btn_reset = xml:Init3tButton("main:btn_reset", self.dialog)
 	self:Register(self.btn_reset, "btn_reset")
 	
-	self.btn_default = xml:Init3tButton("main:btn_default", self.dialog)
-	self:Register(self.btn_default, "btn_default")
+--	self.btn_default = xml:Init3tButton("main:btn_default", self.dialog)
+--	self:Register(self.btn_default, "btn_default")
 	
 	self.btn_cancel = xml:Init3tButton("main:btn_cancel", self.dialog)
 	self:Register(self.btn_cancel, "btn_cancel")

--- a/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/Warfare Patch/gamedata/scripts/ui_options.script
@@ -124,7 +124,7 @@ options = {
 		{ id= "texture_lod"            ,type= "track"    ,val= 2	,cmd= "texture_lod"	                ,min= 0     ,max= 4     ,step= 1 	,no_str= true	  ,invert= true     ,vid= true	,restart= true	},
 		{ id= "geometry_lod"           ,type= "track"    ,val= 2	,cmd= "r__geometry_lod"	            ,min= 0.1   ,max= 1.5   ,step= 0.1 },
 		{ id= "mipbias"           	   ,type= "track"    ,val= 2	,cmd= "r__tf_mipbias"	            ,min= -0.5  ,max= 0.5   ,step= 0.1 	,no_str= true 	  ,invert= true },
-		{ id= "tf_aniso"               ,type= "track"    ,val= 2	,cmd= "r__tf_aniso"	                ,min= 1     ,max= 16    ,step= 4    ,vid= true	},
+		{ id= "tf_aniso"               ,type= "list"     ,val= 0	,cmd= "r__tf_aniso"	                ,content={ {"0","0"},{"4","4"},{"8","8"},{"16","16"} }    ,vid= true, no_str= true	},
 		{ id= "ssample"                ,type= "track"    ,val= 2	,cmd= "r__supersample"	            ,min= 1     ,max= 8     ,step= 1       ,vid= true      ,precondition= {for_renderer,"renderer_r1","renderer_r2a","renderer_r2","renderer_r2.5"} },
 		{ id= "ssample_list"           ,type= "list"     ,val= 0	,cmd= "r3_msaa"	                    ,content={ {"st_opt_off","st_opt_off"},{"2x","x2"},{"4x","x4"},{"8x","x8"} }	    ,vid= true          ,precondition= {for_renderer,"renderer_r3","renderer_r4"} , no_str= true  },
 		{ id= "smaa"           		   ,type= "list"     ,val= 0	,cmd= "r2_smaa"	                    ,content={ {"off","st_opt_off"},{"low","st_opt_low"},{"medium","st_opt_medium"},{"high","st_opt_high"},{"ultra","st_opt_ultra"} } ,precondition= {for_renderer,"renderer_r2a","renderer_r2","renderer_r2.5","renderer_r3","renderer_r4"}, no_str= true  },


### PR DESCRIPTION
Refer to individual commit messages for the base details of changes made. The changes were tested with latest gamma in both story and story+warfare mode with a few new games. Works nicely.

# Further points

Some things I don't know how to modify as I don't know how GAMMA system works, there are also some things that I'd like your thoughts on first.

Regardless of any of the below, warfare is still not truly "supported" with this as it is inherently flaky, buggy and crash-prone at times (also in vanilla Anomaly). However having them enabled by default simplifies maintainership because of good conflict notifications in MO2 meaning more integrated workflow with less chance is breaking warfare mode often when editing other things. Consider this just a quality-of-life for the people that want to play warfare (like me). Good settings and mods are pre-set but be aware of bugs and crashes with no support for those if they happen.

* [ ] Mod `-223- Fluid Relations - Favkis_Nexerade` should be replaced by `Yastin + Favkis Fluid Dynamic Relations`.
  * https://www.moddb.com/mods/stalker-anomaly/addons/yastin-favkis-fluid-dynamic-relations
  * This is a drop-in replacement, they change the same files. No conflicts.
  * This one is recommended by Warfare Alife overhaul author, it's kinda a successor mod.
* [ ] Enable Warfare Alife Overhaul by default.
  * Compared to vanilla warfare this is as good as it gets (which is still not stable).
  * As far as I have read and checked, this mod does nothing when not playing in warfare mode as it only changes warfare system. Concretely there appears to be no downside to enabling by default for non-warfare players.
  * Note that Warfare Patch must also be enabled by default. Perhaps mod order is changed at some point so that this manual patch is no longer needed? That would make it cleaner to maintain, but is out of scope for this patchset.
  * When doing this, make sure to load some WAO preset in the warfare settings (1x or 2x), so the default `user.ltx` supplied by GAMMA has correct settings for WAO. I think 1x is good as GAMMA is pretty desolate by default.
* [ ] Enable Yastin + Favkis Fluid Dynamic Relations by default.
  * This mod overrides the vanilla `Dynamic Faction Relations` system, which is off by default.
  * Even with this mod, one *must manually activate* the `Dynamic Faction Relations` setting first, or it does nothing.
  * Even for only story mode (not warfare), this mod is a good optional feature in my opinion.

# GAMMA Economy simulation_objects_props.ltx

Also, can you check why `G.A.M.M.A. Economy/gamedata/configs/misc/simulation_objects_props.ltx` exists? The only difference compared to vanilla anomaly 1.5.2 is the following, which is only a few stalker and bandit spawns mostly in the cordon. This seems to not belong to GAMMA economy at all?

```diff
diff --git a/../stalker_anomaly_gamma/tools/_unpacked/configs/misc/simulation_objects_props.ltx b/G.A.M.M.A. Economy/gamedata/configs/misc/simulation_objects_props.ltx
old mode 100644
new mode 100755
index f5a012b..9bfea75
--- a/../stalker_anomaly_gamma/tools/_unpacked/configs/misc/simulation_objects_props.ltx
+++ b/G.A.M.M.A. Economy/gamedata/configs/misc/simulation_objects_props.ltx	
@@ -307,9 +307,8 @@ army 			        = 1
 sim_avail 	            = true
 surge		            = 1 
 bandit 		            = 1
-stalker 		        = 1
 
-;�������
+;�������
 [esc_smart_terrain_4_9]:default_lair
 sim_avail 	            = true
 surge 		            = 1 
@@ -331,7 +330,6 @@ sim_avail 	            = true
 surge 		            = 1
 stalker 		        = 1
 csky			        = 1
-bandit		            = 1
 
 ;mill
 [esc_smart_terrain_5_9]:weak_lair
@@ -361,6 +359,7 @@ sim_avail 	            = true
 sim_avail 	            = true
 csky			        = 1
 stalker 		        = 1
+bandit 			        = 1
 
 [esc_smart_terrain_4_11]:weak_lair
 sim_avail 	            = true
@@ -378,9 +377,11 @@ stalker 		        = 1
 
 [esc_smart_terrain_5_4]:weak_lair
 sim_avail 	            = true
+bandit		            = 1
 
 [esc_smart_terrain_5_6]:weak_lair
 sim_avail 	            = true
+bandit		            = 1
 
 ;ruined rail bridge
 [esc_smart_terrain_6_8]:default_base
@@ -392,6 +393,7 @@ bandit		            = 1
 
 [esc_smart_terrain_8_10]:default_lair
 sim_avail 	            = true
+bandit		            = 1
 
 [esc_smart_terrain_8_9]:weak_lair
 sim_avail 	            = true
@@ -399,6 +401,7 @@ stalker 		        = 1
 
 [esc_smart_terrain_9_7]:default_lair
 sim_avail 	            = true
+bandit		            = 1
 
 [esc_smart_terrain_9_10]:weak_lair
 sim_avail 	            = true
@@ -1295,7 +1298,7 @@ sim_avail 	            = true
 [red_smart_terrain_3_1]:default_base
 sim_avail 	            = true
 
-;underground mine �����
+;underground mine �����
 [red_smart_terrain_3_2]:default_resource
 sim_avail 	            = true
 ;lair                    = 1 
```

If the `simulation_objects_props.ltx` is removed from GAMMA economy it can also be removed completely from Warfare Patch and the upstream from Warfare Alife Overhaul can be used directly, much easier to maintain. For now I merged the changes made in GAMMA Economy into Warfare Patch file.

# Known issues

Current Warfare Alife Overhaul does not cleanly merge with survival mode (only zombie spawns). Personally I think survival mode is really gimmicky and adds no value, hence I don't see a reason to fix it.

Perhaps upstream will fix it at some point automatically? See also https://www.moddb.com/mods/stalker-anomaly/addons/warfare-alife-overhaul/page/16#comments