### PR TITLE
Hotfix for rare tushkano caused crash

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Footsteps/gamedata/configs/mod_system_mutant_footsteps_Larkin.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Footsteps/gamedata/configs/mod_system_mutant_footsteps_Larkin.ltx
@@ -320,9 +320,6 @@ stand_look_around_0		=   1,    0.09,   1.0,    0.05,    0.7,    0.54,    1.0,   
 stand_scared_0			=   1,    0.05,   1.0,    0.09,    0.7,    0.90,    1.0,    0.97,    1.0
 stand_threaten_0		=   1,    0.50,   1.0,    0.70,    0.7,    0.81,    1.0,    0.07,    1.0
 
-![m_tushkano_e]
-LegsCount = 4
-
 ![m_tushkano_step_params]
 ;---------------------------------------------------------------------------
 ;	anim				| Cycles | time1 | power1 | time2 | power2 |


### PR DESCRIPTION
Apparently, tushkano were changed to be bipeds. I had them set as quadrupeds. This would extremely rarely cause a crash when a tushkano hand hit the ground.