### PR TITLE
Fix shotgun reload voice spam

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Voiced Actor/gamedata/scripts/AGDD_voiced_actor.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Voiced Actor/gamedata/scripts/AGDD_voiced_actor.script
@@ -412,7 +412,7 @@ function actor_on_weapon_reload(wpn,ammo_total) --calls out reloads
 	already_commented_this_jam = false --clear the marker, actor is fixing the jam
 
 	if is_actor_in_combat() == true then --only plays reload shouts if actor is in combat and has a squad
-		actor_speak("characters_voice\\player" .. lang .. "\\" .. muffle .. "reloading_" .. math.random(7),1.0,1500,75,true,false,false,false)
+		actor_speak("characters_voice\\player" .. lang .. "\\" .. muffle .. "reloading_" .. math.random(7),1.0,8000,75,true,false,false,false)
 		add_action_intensity(40,0.5,175)
 	end
 	


### PR DESCRIPTION
Up reload voiceline cooldown to 8 seconds to avoid spam on every shell.