### PR TITLE
338 Double hit fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/configs/mod_system_gamma_ammo_balance.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/configs/mod_system_gamma_ammo_balance.ltx
@@ -16,3 +16,16 @@ k_bullet_speed    = 1.5
 ![ammo_9x21_sp10]
 cost            = 2550
 
+![ammo_338_federal]
+k_disp			= 0.67
+k_impulse		= 1.8
+k_hit			= 1.28
+k_ap			= 0.85
+tracer_color_ID	= 2
+wm_size         = 0.086
+k_air_resistance = 0.05
+k_cam_dispersion          = 1.5
+k_bullet_speed	= 1.5
+
+![ammo_magnum_300]
+wm_size         = 0.086


### PR DESCRIPTION
Redid 338 parameters to ensure double hits only occur in a realistic manner (IE shooting a low armor limb will still overpen)