### PR TITLE
NPC emission behavior tuning

### DIFF
--- a/G.A.M.M.A/modpack_addons/265- NPCs Die in Emissions for Real - TheMrDemonized/gamedata/configs/scripts/beh_surge.ltx
+++ b/G.A.M.M.A/modpack_addons/265- NPCs Die in Emissions for Real - TheMrDemonized/gamedata/configs/scripts/beh_surge.ltx
@@ -1,0 +1,73 @@
+[logic]
+active = beh@base
+post_combat_time = 0,0
+; trade = items\trade\trade_companion.ltx
+; level_spot = companion  
+
+;======================
+; default logic
+;======================
+[beh@general]
+combat_ignore_keep_when_attacked = false
+combat_ignore_cond = {!in_surge_cover} true, false
+meet = meet
+gather_items_enabled = {=in_surge_cover} true, false
+corpse_detection_enabled = {=in_surge_cover} true, false
+; actor_dialogs = actor_dialogs
+behavior_state = {=in_surge_cover} beh_wait, beh_move
+invulnerable = {=is_warfare} false, {=is_story_npc_and_enemy} false, {=is_story_npc} true, false
+target = surge_cover
+walk_dist = 4
+jog_dist = 8
+run_dist = 40
+; keep_distance = {+npcx_beh_distance_far} far, near
+near_desired_dist = 1
+far_desired_dist = 2
+wait_anim = {=is_wounded} wounded, {=in_surge_cover} hide, guard
+walk_anim = {=is_wounded} wounded, {=in_surge_cover} rush, patrol
+jog_anim = {=is_wounded} wounded, {=in_surge_cover} rush, rush
+run_anim = {=is_wounded} wounded, {=in_surge_cover} panic, panic
+sprint_anim = {=is_wounded} wounded, {=in_surge_cover} panic, panic
+delay_anim = {=is_wounded} wounded, {=in_surge_cover} hide, random_animation
+;out_restr = zat_a2_sr_noweap, jup_a6_sr_noweap, jup_b41_sr_noweap, bar_old_arena, bar_arena
+
+[meet]
+close_anim 		= nil
+close_victim 	= nil
+far_anim 		= nil
+far_victim 		= nil
+close_distance  = 0
+far_distance 	= 0
+use = {=actor_enemy} false, {=dist_to_actor_le(3)} true, false
+snd_on_use = {!dist_to_actor_le(3)} nil
+meet_on_talking = false
+
+
+;===============================================
+;            		 active sections
+;===============================================
+[beh@base]:beh@general
+
+[beh@in_cover]:beh@general
+combat_ignore_keep_when_attacked = false
+combat_ignore_cond = {!in_surge_cover} true, false
+meet = meet
+gather_items_enabled = {=in_surge_cover} true, false
+corpse_detection_enabled = {=in_surge_cover} true, false
+; actor_dialogs = actor_dialogs
+behavior_state = {=random_lvid_reached} beh_wait, beh_move
+target = surge_cover_random_lvid
+invulnerable = {=is_warfare} false, {=is_story_npc_and_enemy} false, {=is_story_npc} true, false
+walk_dist = 4
+jog_dist = 8
+run_dist = 40
+; keep_distance = {+npcx_beh_distance_far} far, near
+near_desired_dist = 1
+far_desired_dist = 2
+wait_anim = {=is_wounded} wounded, hide
+walk_anim = {=is_wounded} wounded, patrol
+jog_anim = {=is_wounded} wounded,  patrol
+run_anim = {=is_wounded} wounded,   panic
+sprint_anim = {=is_wounded} wounded, panic
+delay_anim = {=is_wounded} wounded,  random_animation
+;out_restr = zat_a2_sr_noweap, jup_a6_sr_noweap, jup_b41_sr_noweap, bar_old_arena, bar_arena


### PR DESCRIPTION
Resolves NPCs ignoring combat entirely due to an emission.