### PR TITLE
reshade: Add correct depth-buffer preprocessor defs

### DIFF
--- a/G.A.M.M.A/modpack_patches/bin/ReShade.ini
+++ b/G.A.M.M.A/modpack_patches/bin/ReShade.ini
@@ -7,7 +7,7 @@ UseAspectRatioHeuristics=1
 EffectSearchPaths=.\reshade-shaders\Shaders\qUINT\,.\reshade-shaders\Shaders\PD80\,.\reshade-shaders\Shaders\
 IntermediateCachePath=C:\Users\groki\AppData\Local\Temp
 PerformanceMode=0
-PreprocessorDefinitions=
+PreprocessorDefinitions=RESHADE_DEPTH_LINEARIZATION_FAR_PLANE=1000.0,RESHADE_DEPTH_INPUT_IS_UPSIDE_DOWN=0,RESHADE_DEPTH_INPUT_IS_REVERSED=0,RESHADE_DEPTH_INPUT_IS_LOGARITHMIC=0
 PresetPath=.\G.A.M.M.A.Reshade.ini
 PresetTransitionDelay=1000
 SkipLoadingDisabledEffects=0


### PR DESCRIPTION
* Out of the box, without any preprocessor definitions, reshade is going to use RESHADE_DEPTH_INPUT_IS_REVERSED=1 which results in a broken depth buffer with Stalker. In the interest of saving people time and headache diagnosing why depth buffer aware shaders aren't working correctly, just set all the appropriate depth buffer defs up front.