### PR TITLE
(ISG Teleport) Add missing return to teleport roll

### DIFF
--- a/G.A.M.M.A/modpack_addons/Fuji's ISG Teleport/gamedata/scripts/fuji_magician.script
+++ b/G.A.M.M.A/modpack_addons/Fuji's ISG Teleport/gamedata/scripts/fuji_magician.script
@@ -165,6 +165,7 @@ function npc_on_before_hit(npc,shit,bone_id)
   
   if(not one_in(teleport_chance)) then
     printf("[Fuji] Bad roll, aborting")
+    return
   end
   
   if(npc:dont_has_info("magic_muggle")) then


### PR DESCRIPTION
Return was missing from the teleport roll, meaning failure would always cascade into a teleport anyway.