### PR TITLE
Re-adds dialog for Hidden Threat military questline

### DIFF
--- a/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/configs/gameplay/character_desc_agroprom.xml
+++ b/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/configs/gameplay/character_desc_agroprom.xml
@@ -34,6 +34,15 @@
 		<actor_dialog>drx_sl_agr_smart_terrain_1_6_near_2_military_colonel_kovalski_game_start_dialog_1</actor_dialog>
 		<actor_dialog>drx_sl_cf_task_completed_dialog</actor_dialog>
 		<actor_dialog>drx_sl_task_completed_dialog</actor_dialog>
+		<!------------ Hidden Threat ------------>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d1</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d2</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d3</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d4</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d5</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d6</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kuznetsov_d7</actor_dialog>
+		<!--------------------------------------->
 		<actor_dialog>dm_ordered_task_completed_dialog</actor_dialog>
 		<actor_dialog>drx_sl_agr_smart_terrain_1_6_near_2_military_colonel_kovalski_meet_dialog</actor_dialog>
                 <actor_dialog>est_work_kuznecov</actor_dialog>
@@ -71,8 +80,15 @@
 		
 #include "gameplay\character_criticals.xml"
 
+		<!------ Hidden Threat ----->
+		<start_dialog>sl_hidden_threat_dialog_spooner_d1</start_dialog>
+		<!-------------------------->
 		<start_dialog>hello_dialog</start_dialog>
 		<actor_dialog>dm_init_trader</actor_dialog>
+		<!------ Hidden Threat ----->
+		<actor_dialog>sl_hidden_threat_dialog_spooner_d2</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_spooner_d3</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_spooner_d4</actor_dialog>
 		<!---------- mlr ----------->
 		<actor_dialog>guid_agr_mlr_military</actor_dialog>
 		<actor_dialog>guid_agr_mlr_military_vert</actor_dialog>
@@ -115,8 +131,15 @@
 		</supplies>
 		
 #include "gameplay\character_criticals.xml"
+		  <!------ Hidden Threat ----->
+		<start_dialog>sl_hidden_threat_dialog_kirillov_d1</start_dialog>
+		<!-------------------------->
 		<actor_dialog>dm_init_trader</actor_dialog>
 		<actor_dialog>dm_init_mechanic</actor_dialog>
+		<!------ Hidden Threat ----->
+		<actor_dialog>sl_hidden_threat_dialog_kirillov_d2</actor_dialog>
+		<actor_dialog>sl_hidden_threat_dialog_kirillov_d3</actor_dialog>
+		<!-------------------------->
 		<actor_dialog>drx_sl_task_completed_dialog</actor_dialog>
 		<actor_dialog>dm_ordered_task_completed_dialog</actor_dialog>
 		<actor_dialog>drx_sl_agr_smart_terrain_1_6_army_mechanic_stalker_meet_dialog</actor_dialog>

--- a/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/configs/gameplay/character_desc_escape.xml
+++ b/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/configs/gameplay/character_desc_escape.xml
@@ -315,7 +315,9 @@
 		<actor_dialog>dm_init_trader</actor_dialog>
 		<actor_dialog>dm_ordered_task_dialog</actor_dialog>
 		<actor_dialog>dm_ordered_task_completed_dialog</actor_dialog>
-		
+		<!------------ Hidden Threat ------------>
+		<actor_dialog>sl_hidden_threat_dialog_jurov</actor_dialog>
+		<!--------------------------------------->
 		<actor_dialog>guid_esc_mlr_military</actor_dialog>
 		<actor_dialog>guid_esc_mlr_military_vert</actor_dialog>
 		<actor_dialog>guid_esc_mlr_military_list</actor_dialog>


### PR DESCRIPTION
Modifies the character files for Agroprom and Cordon to re-add the necessary dialog options to start and progress through the Hidden Threat quest to the armor exchange file that takes priority but doesn't have them.