### PR TITLE
Change military to monolith patches to be more consistent with other patch quests.

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/configs/mod_system_monster_poison.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/configs/mod_system_monster_poison.ltx
@@ -212,6 +212,23 @@ boost_radiation_protection                         = 0
 boost_radiation_restore		                       = 0
 boost_time					                       = 3000
 
-
+![meat_psysucker]
+eat_satiety				                           = 0.242
+eat_radiation		                               = 0.027
+eat_health			                               = -0.0280
+![meat_psysucker_b]
+eat_satiety				                           = 0.385
+eat_radiation		                               = 0.0135
+eat_health			                               = 0
+![meat_psysucker_a]
+eat_satiety				                           = 0.454
+eat_health			                               = 0
+boost_max_weight			                       = 0
+boost_bleeding_restore		                       = 0
+boost_health_restore		                       = 0
+boost_radiation_protection	                       = 0
+boost_telepat_protection 	                       = 0.063
+boost_radiation_restore		                       = 0
+boost_time					                       = 3800
 
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Dynamic Tasks Balance/gamedata/configs/items/settings/fetch_list.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Dynamic Tasks Balance/gamedata/configs/items/settings/fetch_list.ltx
@@ -847,7 +847,7 @@
 
 [patch_mlr_duty] 
 	freedom_patch                      = true
-	army_patch                         = true
+	monolith_patch                     = true
 	bandit_patch                       = true
 	killer_patch                       = true
 	renegade_patch                     = true


### PR DESCRIPTION
After reviewing the other factions patch requests, there are no instances where members of a faction will request patches of an ally. I have replaced the military patch requests with monolith as they share a common enemy with military although I could see just removing the line entirely.

Note: I started this edit on the dev branch but it does not seem to include the new artifact patch changes made in version 0.9.1