### PR TITLE
Assorted bug fixes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Items Parts Fixes/gamedata/configs/items/settings/parts.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Items Parts Fixes/gamedata/configs/items/settings/parts.ltx
@@ -388,6 +388,7 @@ wpn_desert_eagle                =   prt_w_p_barrel_7,	prt_w_p_trigger_1,				prt_
 wpn_desert_eagle_custom         =   prt_w_p_barrel_7,	prt_w_p_trigger_1,				prt_w_p_spring_6
 wpn_desert_eagle_modern         =   prt_w_p_barrel_7,	prt_w_p_trigger_1,				prt_w_p_spring_6
 wpn_desert_eagle_nimble         =   prt_w_p_barrel_7,	prt_w_p_trigger_1,				prt_w_p_spring_6
+wpn_desert_eagle_steppe         =   prt_w_p_barrel_7,	prt_w_p_trigger_1,				prt_w_p_spring_6
 wpn_mp412                       =   prt_w_p_barrel_7,	prt_w_p_trigger_4
 wpn_thompson_m1a1                       =	 prt_w_barrel_11,	prt_w_trigger_components_2,		prt_w_bolt_carrier_11, 		prt_w_bolt_16, 		prt_w_gas_tube_4
 wpn_thompson_1921                       =	 prt_w_barrel_11,	prt_w_trigger_components_2,		prt_w_bolt_carrier_5, 		prt_w_bolt_16, 		prt_w_gas_tube_4

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
@@ -27,4 +27,5 @@ cost                                                   = 774
 visual = dynamics\wpn\mags\wpn_mp7_mag.ogf
 
 base_type											   = mp7_5.7x28
+retool_group                     = mp7_default
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
@@ -14,9 +14,9 @@
 
 
 [mag_mp7_5.7x28_default]:tch_mag_base
-description			                                   = st_mag_mp7_9x19_fmj_descr
-inv_name			                                   = st_mag_mp7_9x19_fmj
-inv_name_short		                                   = st_mag_mp7_9x19_fmj
+description			                                   = st_mag_mp7_5.7x28_ss190
+inv_name			                                   = st_mag_mp7_5.7x28_ss190
+inv_name_short		                                   = st_mag_mp7_5.7x28_ss190
 
 inv_grid_x                     					       = 1
 inv_grid_y               				               = 8

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/items/weapons/magazines2/mag_mp7_57.ltx
@@ -14,7 +14,7 @@
 
 
 [mag_mp7_5.7x28_default]:tch_mag_base
-description			                                   = st_mag_mp7_5.7x28_ss190
+description			                                   = st_mag_mp7_5.7x28_ss190_descr
 inv_name			                                   = st_mag_mp7_5.7x28_ss190
 inv_name_short		                                   = st_mag_mp7_5.7x28_ss190
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_g36k_rwap.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_g36k_rwap.ltx
@@ -1,0 +1,4 @@
+[wpn_g36k_rwap]
+default_mag = mag_g36_5.56x45_default
+;base_type
+ammo_5.56x45_fmj = g36_5.56x45

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_p90_gs.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_p90_gs.ltx
@@ -1,0 +1,4 @@
+[wpn_p90_gs]
+default_mag = mag_p90_5.7x28_default
+;base_type
+ammo_5.7x28_ss190 = p90_5.7x28

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_p90gamma.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_p90gamma.ltx
@@ -1,0 +1,4 @@
+[wpn_p90gamma]
+default_mag = mag_p90_5.7x28_default
+;base_type
+ammo_5.7x28_ss190 = p90_5.7x28

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_smg_other.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_smg_other.ltx
@@ -21,3 +21,4 @@ ammo_5.7x28_ss190 = p90_5.7x28
 default_mag = mag_mp7_5.7x28_default
 ;base_type
 ammo_5.7x28_ss190 = mp7_5.7x28
+ammo_9x18_fmj = mp7_9x18

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/text/eng/st_items_magazines_fix.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/text/eng/st_items_magazines_fix.xml
@@ -33,4 +33,11 @@
 		<text>High capacity 9x19 magazine for KRISS Vector holding up to 50 rounds. Made in Korea, imported by SGM Tactical. Loading more than 50 rounds is not recommended by the manufacturer.</text>
 	</string>
 
+	<string id="st_mag_mp7_5.7x28_ss190">
+		<text>Modified 5.7x28 MP7 Magazine</text>
+	</string>
+	<string id="st_mag_mp7_5.7x28_ss190_descr">
+		<text>40-round extended MP7 magazine modified to accept the 5.7x28mm round developed and manufactured by FN Herstal. Due to the somewhat rare nature of 4.6x30 rounds, some thrifty technicians were able to retrofit the MP7 to fire the same round as the FN P90 and Five Seven.</text>
+	</string>
+
 </string_table>


### PR DESCRIPTION
Apologies if I screwed this up somehow, this is my first time using github and I made an account specifically to post this. I noticed several minor bugs while playing gamma and managed to fix them as far as I can tell, so I am posting my fixes here.

1. Adds mag support to wpn_g36k_rwap, wpn_p90_gs, and wpn_p90gamma, allowing them to use the already-existing p90 and G36K mags.
2. Fixes a wpn_desert_eagle_steppe bug that causes all its parts to disappear when you try and attach a sight to it.
3. Fixes several Mags-related bugs and issues related to wpn_mp7, including incorrect name and description for the 5.7x28mm mag, the alt caliber (9x18mm) not having mag support, and the inability to retool the 5.7x28mm mag into the 9x18mm mag.