### PR TITLE
Fixes UNISG mechanic supply levels

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_isg_mission.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_isg_mission.ltx
@@ -5,7 +5,7 @@
 [trader]
 buy_condition = trade_generic_buy
 sell_condition = trade_generic_sell
-buy_supplies = {+jup_depo_isg_tech_task_3} supplies_5, {+jup_depo_isg_tech_task_2} supplies_4, {+jup_depo_isg_tech_task_1} supplies_3, {+lttz_hb_isg_breakthrough} supplies_2,  supplies_1
+buy_supplies = {+jup_depo_isg_tech_upgrade_tier_3} supplies_5, {+jup_depo_isg_tech_upgrade_tier_2} supplies_4, {+jup_depo_isg_tech_upgrade_tier_1} supplies_3, {+lttz_hb_isg_breakthrough} supplies_2,  supplies_1
 buy_item_condition_factor =  0.01	;0.40
 buy_item_exponent = 1.75
 sell_item_exponent = 0.75
@@ -19,6 +19,39 @@ itm_pda_uncommon                         ;NO TRADE
 pri_a25_explosive_charge_item            ;NO TRADE
 
 [trade_generic_sell]:mechanic, toolkits_h
+kit_hunt                = 1.0,1.0
+glucose_s				= 1.0,1.0
+glucose					= 1.0,1.0
+drug_sleepingpills		= 1.0,1.0
+bandage					= 1.0,1.0
+medkit					= 1.0,1.0
+medkit_ai1				= 1.0,1.0
+antirad_cystamine		= 1.0,1.0
+antibio_chlor			= 1.0,1.0
+jgut					= 1.0,1.0
+yadylin					= 1.0,1.0
+analgetic				= 1.0,1.0
+antirad_kalium			= 1.0,1.0
+antibio_sulfad			= 1.0,1.0
+antiemetic   			= 1.0,1.0
+medkit_army				= 1.0,1.0
+antirad					= 1.0,1.0
+stimpack				= 1.0,1.0
+caffeine				= 1.0,1.0
+protein					= 1.0,1.0
+akvatab					= 1.0,1.0
+cocaine					= 1.0,1.0
+tetanus					= 1.0,1.0
+adrenalin				= 1.0,1.0
+salicidic_acid			= 1.0,1.0
+morphine				= 1.0,1.0
+drug_anabiotic			= 1.0,1.0
+drug_booster			= 1.0,1.0
+drug_coagulant			= 1.0,1.0
+drug_antidot			= 1.0,1.0
+drug_radioprotector		= 1.0,1.0
+drug_psy_blockade		= 1.0,1.0
+kerosene                = 1.0,1.0
 
 [supplies_1]:common_stock		;-- no tools
 ;-- Recipes


### PR DESCRIPTION
Changed the supply levels to evaluate the proper condition set by the task script. It was mistakenly pointing to the task name instead.
Added his current drug/general supplies to [trade_generic_sell] section to allow him to sell them.

NOTE: I noticed he has an exo_repair_kit available at supplies_5, I left untouched unsure if it is intended.

(this is my first time doing a pull request, hopefully I'm doing it right)