### PR TITLE
Fix for Wepl Hit Effects callback not registering for NPC hits

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
@@ -19,7 +19,7 @@ local headBones = {
 
 function on_game_start()
 	RegisterScriptCallback( "actor_on_before_hit", actor_on_before_hit )
-	RegisterScriptCallback( "npc_on_before_hit", npc_on_hit_callback )
+	RegisterScriptCallback( "npc_on_before_hit", npc_on_before_hit )
 end
 
 
@@ -85,7 +85,12 @@ function actor_on_before_hit( hit, boneId, flags )
 end
 
 
-function npc_on_hit_callback( npc, damage, dir, attacker, boneId )
+function npc_on_before_hit(npc,shit,bone_id,flags)
+	local npc = npc
+	local damage = shit.power
+	local attacker = shit.draftsman
+	local boneId = bone_id
+
 	if not ( npc and damage and attacker and boneId ) then return end
 	if damage == 0 or damage == 1 then return end
 	


### PR DESCRIPTION
Hits on NPCs are not triggering the Wepl On Hit Effects. It looks like the "npc_on_before_hit" prototype changed recently and now passes different arguments.