### PR TITLE
Fix for Wepl Hit Effects callback not registering for NPC hits

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/configs/text/eng/ui_st_wepl_hit_effect.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/configs/text/eng/ui_st_wepl_hit_effect.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="windows-1251"?>
+
+<!-- 
+	MCM
+-->
+<string_table>
+
+
+	<string id="ui_mcm_wepl_hit_effect_title">
+		<text>Wepl Hit Effects</text>
+	</string>
+	<string id="ui_mcm_menu_wepl_hit_effect">
+		<text>Wepl Hit Effects</text>
+	</string>
+
+
+	<!-- Main configs -->
+	<string id="ui_mcm_wepl_hit_effect_enable_stalker">
+		<text>Enable on hit sound for player</text>
+	</string>
+
+	<string id="ui_mcm_wepl_hit_effect_enable_npc">
+		<text>Enable sound when player hits an NPC</text>
+	</string>
+
+	<string id="ui_mcm_wepl_hit_effect_volume">
+		<text>Volume of the on hit sound</text>
+	</string>
+
+</string_table>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
@@ -14,17 +14,24 @@ local headBones = {
 	[19] = true
 }
 
+-- mcm configs
+local enable_for_stalkers = wepl_hit_effect_mcm.get_config("enable_stalker")
+local enable_for_npcs = wepl_hit_effect_mcm.get_config("enable_npc")
 
+local volume = wepl_hit_effect_mcm.get_config("volume")
 
 
 function on_game_start()
 	RegisterScriptCallback( "actor_on_before_hit", actor_on_before_hit )
 	RegisterScriptCallback( "npc_on_before_hit", npc_on_before_hit )
+	RegisterScriptCallback("save_state", save_state)
+	RegisterScriptCallback("load_state", load_state)
+	RegisterScriptCallback("on_option_change", on_option_change)
 end
 
 
 function actor_on_before_hit( hit, boneId, flags )
-	if not ( hit and hit.type and hit.power and boneId ) then return end
+	if not ( enable_for_stalkers and hit and hit.type and hit.power and boneId ) then return end
 	
 	if hit.power == 0 then return end
 	if not ( hit.type == 5 or hit.type == 6 or hit.type == 7 or hit.type == 8 ) then return end
@@ -77,8 +84,8 @@ function actor_on_before_hit( hit, boneId, flags )
 	
 	local ActorhitSound = sound_object("wepl\\hit_effect\\" .. hitType .. "\\hit_" .. hitEffect .. "_" .. math.random(20) )
 	if ActorhitSound then
-        ActorhitSound:play(db.actor, 0, sound_object.s2d) 
-        ActorhitSound.volume = 0.9
+		ActorhitSound:play(db.actor, 0, sound_object.s2d) 
+		ActorhitSound.volume = volume
 	end
 	
 	level.add_cam_effector( "camera_effects\\wepl\\hit_effect\\" .. hitType .. "\\hit_" .. hitEffect .. "_" .. math.random(5) .. ".anm", math.random(444555, 444999), false, "", 0, true, cam_power )
@@ -91,7 +98,7 @@ function npc_on_before_hit(npc,shit,bone_id,flags)
 	local attacker = shit.draftsman
 	local boneId = bone_id
 
-	if not ( npc and damage and attacker and boneId ) then return end
+	if not ( enable_for_npcs and npc and damage and attacker and boneId ) then return end
 	if damage == 0 or damage == 1 then return end
 	
 	local ply = db.actor
@@ -127,12 +134,26 @@ function npc_on_before_hit(npc,shit,bone_id,flags)
 	local NPChitSound = xr_sound.get_safe_sound_object( "wepl\\hit_effect\\" .. hitType .. "\\hit_" .. hitEffect .. "_" .. math.random(20) )
 	if NPChitSound then
 		NPChitSound:play_at_pos( ply, npc:position() )
-		NPChitSound.volume = 0.9
+		NPChitSound.volume = volume
 		NPChitSound.frequency = random_float(0.95, 1.05)
 	end
 end
 
 
+function save_state(m_data)
+	m_data.obj_t = obj_t
+end
+
+function load_state(m_data)
+	obj_t = m_data.obj_t or {}
+end
+
+function on_option_change()
+	enable_for_stalkers = wepl_hit_effect_mcm.get_config("enable_stalker")
+	enable_for_npcs = wepl_hit_effect_mcm.get_config("enable_npc")
+
+	volume = wepl_hit_effect_mcm.get_config("volume")
+end
 
 
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect.script
@@ -19,7 +19,7 @@ local headBones = {
 
 function on_game_start()
 	RegisterScriptCallback( "actor_on_before_hit", actor_on_before_hit )
-	RegisterScriptCallback( "npc_on_before_hit", npc_on_hit_callback )
+	RegisterScriptCallback( "npc_on_before_hit", npc_on_before_hit )
 end
 
 
@@ -85,7 +85,12 @@ function actor_on_before_hit( hit, boneId, flags )
 end
 
 
-function npc_on_hit_callback( npc, damage, dir, attacker, boneId )
+function npc_on_before_hit(npc,shit,bone_id,flags)
+	local npc = npc
+	local damage = shit.power
+	local attacker = shit.draftsman
+	local boneId = bone_id
+
 	if not ( npc and damage and attacker and boneId ) then return end
 	if damage == 0 or damage == 1 then return end
 	

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect_mcm.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Wepl Hit Effects Rework/gamedata/scripts/wepl_hit_effect_mcm.script
@@ -1,0 +1,25 @@
+-- If you don't use MCM, change your defaults from here.
+local defaults = {
+	["enable_stalker"] = true,
+	["enable_npc"] = true,
+	["volume"] = 0.9
+}
+
+function get_config(key)
+	if ui_mcm then return ui_mcm.get("wepl_hit_effect/"..key) else return defaults[key] end
+end
+
+function on_mcm_load()
+	op = { id= "wepl_hit_effect",sh=true ,gr={
+			{ id= "title",type= "slide",link= "ui_options_slider_player",text="ui_mcm_wepl_hit_effect_title",size= {512,50},spacing= 20 },
+
+			{id = "enable_stalker", type = "check", val = 1, def = true},
+			{id = "enable_npc", type = "check", val = 1, def = true},
+
+			{id= "divider", type = "line" },
+			{id = "volume", type = "track", val = 2, min=0.1,max=2,step=0.1, def = 0.9}
+		}
+	}
+
+	return op
+end


### PR DESCRIPTION
Hits on NPCs are not triggering the Wepl On Hit Effects. It looks like the "npc_on_before_hit" prototype changed recently and now passes different arguments.

Keep up the great work @Grokitach!!!