### PR TITLE
GitHub syntax highlighting for ltx/script files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.xml encoding=windows-1251
+*.ltx linguist-language=INI
+*.script linguist-language=Lua


### PR DESCRIPTION
Configures GitHub's Linguist to recognize these non-standard extensions as certain syntax. Will improve browsing of viewing files online. See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md for documentation