### PR TITLE
Remove guns + duplicate axe from Sin trader

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_greh.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_greh.ltx
@@ -173,7 +173,6 @@ ammo_7.92x33_ap                      = 4, 1
 
 ;[Melee]
 wpn_knife3                           = 1, 1
-wpn_axe                             = 1, 1
 
 ;[Backpacks]
 
@@ -207,16 +206,6 @@ ammo_pkm_100                         = 20, 1
 ammo_og-7b                           = 1, 1
 ammo_vog-25                          = 1, 1
 ammo_vog-30                          = 1, 1
-
-;[Rifle]
-wpn_g36                              = 1, 1
-wpn_l85_modern                       = 1, 1
-wpn_l96a1                            = 1, 1
-wpn_m4a1_camo                        = 1, 1
-wpn_rg-6                             = 1, 1
-wpn_rpg7                             = 1, 1
-wpn_sig552                           = 1, 1
-wpn_sv98                             = 1, 1
 
 ;[Melee]
 wpn_knife5                           = 1, 1

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_greh.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_greh.ltx
@@ -44,7 +44,6 @@ ammo_23x75_barrikada           = 1, 1
 wpn_knife                            = 1, 1
 wpn_knife2                           = 1, 1
 wpn_axe                              = 1, 1
-wpn_axe2                             = 1, 1
 
 ;[Backpacks]
 itm_backpack                         = 1, 1


### PR DESCRIPTION
Removes leftover guns and duplicated axe from Sin trader profile. Thanks to Oflin for spotting this.