### PR TITLE
Remove debug-only guns from npc_loadout__name.ltx

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts__name.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts__name.ltx
@@ -1,5 +1,6 @@
 ;-- Define loadout per npc's section name here
 ;-- You can also reuse loadouts and slots of existing files
+;-- Modified to remove or replace debug-only GAMMA guns.
 
 ;------------------------------------------------------------------------------------------------------------
 ;-- NPC section name = some_loadout
@@ -27,7 +28,7 @@ primary = monolith_sniper_primary	;monolith_rg6_primary
 secondary = monolith_veteran_secondary
 
 [loadout_monolith_gauss]
-primary = monolith_gauss_primary
+primary = monolith_sniper_primary ;monolith_gauss_primary
 secondary = monolith_veteran_secondary
 
 [loadout_army_ssu]
@@ -44,26 +45,26 @@ secondary = blackops_secondary
 
 [blackops_primary]
 wpn_mp7:4:1
-wpn_ump45:4:r
+wpn_ump45_custom:4:r     ;wpn_ump45
 wpn_p90:4:r
-wpn_hk417:4:r
-wpn_m4:4:r
+;wpn_hk417:4:r
+wpn_m4_tac:4:r           ;wpn_m4
 wpn_spas12_custom:r:r
 
 [blackops_secondary]
-wpn_sig220:4:1
-wpn_sig220_custom:4:r
-wpn_usp:4:r
+wpn_sig220_n:4:1         ;wpn_sig220
+wpn_sig220_n_upg220:4:r  ;wpn_sig220_custom
+wpn_usp_match:4:r        ;wpn_usp
 wpn_fn57:4:r
 
 [ssu_primary]
 wpn_9a91:4:r
-wpn_val_modern:r:r
+wpn_val:r:r              ;wpn_val_modern
 wpn_groza:r:r
 wpn_vihr:4:r
 wpn_ash12:r:r
-wpn_ak74u_snag:0:r
-wpn_saiga12s:4:r
+wpn_ak74u_tac:0:r        ;wpn_ak74u_snag
+wpn_saiga12s_m1:4:r      ;wpn_saiga12s
 wpn_groza_nimble:0:r
 
 [ssu_secondary]
@@ -76,44 +77,44 @@ wpn_vityaz:4:r
 [army_sniper_primary]
 ; wpn_vssk
 ; wpn_vssk:0:r
-wpn_svd:1
-wpn_svd:1:r
-wpn_svd_custom:1
-wpn_svd_custom:1:r
+wpn_svd_m1:1             ;wpn_svd
+wpn_svd_m1:1:r
+;wpn_svd_custom:1
+;wpn_svd_custom:1:r
 wpn_svu:1
 wpn_svu:1:r
-wpn_svu_alt:1
-wpn_svu_alt:1:r
+;wpn_svu_alt:1
+;wpn_svu_alt:1:r
 wpn_sv98
 wpn_sv98:0:r
-wpn_sv98_custom
-wpn_sv98_custom:0:r
+;wpn_sv98_custom
+;wpn_sv98_custom:0:r
 
 [monolith_sniper_primary]
 wpn_vssk
 wpn_vssk:0:1
-wpn_svd:1
-wpn_svd:1:r
-wpn_svd_custom:1
-wpn_svd_custom:1:r
+wpn_svd_m1:1             ;wpn_svd
+wpn_svd_m1:1:r
+;wpn_svd_custom:1
+;wpn_svd_custom:1:r
 wpn_svu:1
 wpn_svu:1:r
-wpn_svu_alt:1
-wpn_svu_alt:1:r
+;wpn_svu_alt:1
+;wpn_svu_alt:1:r
 wpn_sv98
 wpn_sv98:0:r
-wpn_sv98_custom
-wpn_sv98_custom:0:r
-wpn_sig550_sniper
-wpn_sig550_sniper:0:r
-wpn_l96a1
-wpn_l96a1m
-wpn_trg
+;wpn_sv98_custom
+;wpn_sv98_custom:0:r
+;wpn_sig550_sniper
+wpn_sr25:0:r                ;wpn_sig550_sniper:0:r
+wpn_remington700            ;wpn_l96a1
+wpn_remington700_magpul_pro ;wpn_l96a1m
+wpn_remington700_lapua700   ;wpn_trg
 
 
-[monolith_rg6_primary]
+[monolith_rg6_primary] ;Unused
 wpn_rg-6
 wpn_m79
 
-[monolith_gauss_primary]
+[monolith_gauss_primary] ;Unused
 wpn_gauss

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts__name.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts__name.ltx
@@ -1,0 +1,119 @@
+;-- Define loadout per npc's section name here
+;-- You can also reuse loadouts and slots of existing files
+
+;------------------------------------------------------------------------------------------------------------
+;-- NPC section name = some_loadout
+[loadouts_per_name]
+sim_default_military_3_sniper   = loadout_army_sniper
+sim_monolith_sniper   			= loadout_monolith_sniper
+sim_monolith_specnaz_rg6        = loadout_monolith_rg6
+sim_monolith_sniper_gauss       = loadout_monolith_gauss
+sim_default_military_5			= loadout_army_ssu
+sim_default_isg_5				= loadout_isg_blackops
+
+
+;------------------------------------------------------------------------------------------------------------
+;-- Loadouts
+[loadout_army_sniper]
+primary = army_sniper_primary
+secondary = army_experienced_secondary
+
+[loadout_monolith_sniper]
+primary = monolith_sniper_primary
+secondary = monolith_veteran_secondary
+
+[loadout_monolith_rg6]
+primary = monolith_sniper_primary	;monolith_rg6_primary
+secondary = monolith_veteran_secondary
+
+[loadout_monolith_gauss]
+primary = monolith_gauss_primary
+secondary = monolith_veteran_secondary
+
+[loadout_army_ssu]
+primary = ssu_primary
+secondary = ssu_secondary
+
+[loadout_isg_blackops]
+primary = blackops_primary
+secondary = blackops_secondary
+
+
+;------------------------------------------------------------------------------------------------------------
+;-- Slots
+
+[blackops_primary]
+wpn_mp7:4:1
+wpn_ump45:4:r
+wpn_p90:4:r
+wpn_hk417:4:r
+wpn_m4:4:r
+wpn_spas12_custom:r:r
+
+[blackops_secondary]
+wpn_sig220:4:1
+wpn_sig220_custom:4:r
+wpn_usp:4:r
+wpn_fn57:4:r
+
+[ssu_primary]
+wpn_9a91:4:r
+wpn_val_modern:r:r
+wpn_groza:r:r
+wpn_vihr:4:r
+wpn_ash12:r:r
+wpn_ak74u_snag:0:r
+wpn_saiga12s:4:r
+wpn_groza_nimble:0:r
+
+[ssu_secondary]
+wpn_pp2000:4:r
+wpn_oc33:4:r
+wpn_vityaz:4:r
+
+
+
+[army_sniper_primary]
+; wpn_vssk
+; wpn_vssk:0:r
+wpn_svd:1
+wpn_svd:1:r
+wpn_svd_custom:1
+wpn_svd_custom:1:r
+wpn_svu:1
+wpn_svu:1:r
+wpn_svu_alt:1
+wpn_svu_alt:1:r
+wpn_sv98
+wpn_sv98:0:r
+wpn_sv98_custom
+wpn_sv98_custom:0:r
+
+[monolith_sniper_primary]
+wpn_vssk
+wpn_vssk:0:1
+wpn_svd:1
+wpn_svd:1:r
+wpn_svd_custom:1
+wpn_svd_custom:1:r
+wpn_svu:1
+wpn_svu:1:r
+wpn_svu_alt:1
+wpn_svu_alt:1:r
+wpn_sv98
+wpn_sv98:0:r
+wpn_sv98_custom
+wpn_sv98_custom:0:r
+wpn_sig550_sniper
+wpn_sig550_sniper:0:r
+wpn_l96a1
+wpn_l96a1m
+wpn_trg
+
+
+[monolith_rg6_primary]
+wpn_rg-6
+wpn_m79
+
+[monolith_gauss_primary]
+wpn_gauss


### PR DESCRIPTION
This file was never overwritten and is still using DICK's copy designed for vanilla Anomaly. Changed it to be in-line with GAMMA guns. Double check gun changes if necessary.