### PR TITLE
Fix tourniquet not being added to starter loadouts

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Loadouts/gamedata/configs/items/settings/new_game_loadouts.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Loadouts/gamedata/configs/items/settings/new_game_loadouts.ltx
@@ -67,7 +67,6 @@ antirad_kalium                  = true,2,25
 drug_psy_blockade               = true,2,50
 glucose_s						= true,2,15
 medkit 					        = true,4,75
-jgut							= true,2,50
 drug_anabiotic			        = true,1,100
 akvatab                         = true,2,100
 drug_antidot					= true,2,100


### PR DESCRIPTION
Right now the line adding a tourniquet to the default loadout is overwritten by the one letting you buy tourniquets for points.