### PR TITLE
Monkey patch prevention

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/grok_bo.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/grok_bo.script
@@ -2,7 +2,12 @@ custom_bone_value	= {} -- this a table with each identifier being npcid_boneid, 
 custom_bone_ap	= {} 
 custom_bone_hf	= {} 
 custom_bone_dmg	= {}
+custom_bone_real_ap = {}
+custom_bone_power = {}
 invincible_npcs_sections = {}
+
+headshot_feedback_particle = "anomaly2\\effects\\body_tear_blood_01"
+headshot_feedback_enable = true
 ini_capture	 = ini_file("creatures\\grok_bo_models_capture.ltx")
 ini_bones		 = ini_file("creatures\\grok_bo_bone_profiles.ltx")
 ini_damage		= ini_file("creatures\\damages.ltx")
@@ -845,6 +850,9 @@ function npc_on_before_hit(npc,shit,bone_id)
 
 	shit.power = wpn_hit_power / ( 1 + dist / 200 * ( air_res * 0.5 / ( 1 - air_res + 0.1 ))) * k_hit * custom_bone_dmg_mult * custom_bone_ap_scale * 1.1 * sniper_bad_bone_shit_reduce * barrel_condition_corrected * sin_res * difficulty_multiplier[game_num] * ammo_mult * silencer_boost
 
+	custom_bone_real_ap[custom_bone_id] = k_ap
+	custom_bone_power[custom_bone_id] = shit.power
+
 	-- etapomom: run pba before armor so that they actually feel like they're doing something.
 	pbadamage = hit(shit)
 	PBA_obh(npc, pbadamage, bone_id, flags)
@@ -879,8 +887,8 @@ function npc_on_before_hit(npc,shit,bone_id)
 	end
 	
 	-- Add even more feedback on headshots
-	if (k_ap > new_bone_armor) and headBones[bone_id] then
-		fx = particles_object("anomaly2\\effects\\body_tear_blood_01")
+	if (k_ap > new_bone_armor) and headBones[bone_id] and headshot_feedback_enable then
+		fx = particles_object(headshot_feedback_particle)
 		pos = npc:bone_position(custom_bone_name)
 		fx:play_at_pos(pos)
 	end


### PR DESCRIPTION
Two things in this PR:
- Please share your `s_hit.power` and `k_ap` calculations so that other mods/scripts can leverage them

> I've been working on a mod that requires an accurate `s_hit.power` and right now there isn't really a great way to get that since `grok_bo` sets it to 0. There are a few workarounds but I've found them inconsistent and prone to break when grok_bo is updated. This way everyone will have access to the same calculations

- Break at least the headshot particle into a variable that can be changed

> A bunch of mods that touch on effects include or recommend including a monkey patch of this script just to prevent that one particle being played on headshot. I couldn't find a way to define it in DLTX so there might be a better way here

Keep up the great work @Grokitach and let me know if there's anything i can do to make your life easier

- (sunn in discord)

