### PR TITLE
update English and Russian ui labels for scopes/kits

### DIFF
--- a/G.A.M.M.A/modpack_addons/287- G.A.M.M.A. Massive Text Overhaul Project - SageDaHerb and Dr.Pr1nkos/gamedata/configs/text/rus/ui_st_inventory.xml
+++ b/G.A.M.M.A/modpack_addons/287- G.A.M.M.A. Massive Text Overhaul Project - SageDaHerb and Dr.Pr1nkos/gamedata/configs/text/rus/ui_st_inventory.xml
@@ -913,7 +913,7 @@
 		<text>Нет активного КПК</text>
 	</string>
 	<string id="st_ui_scopes">
-		<text>Прицелы</text>
+		<text>Прицелы и Комплекты</text>
 	</string>
 	<string id="st_ui_silencer">
 		<text>Прибор бесшумной стрельбы</text>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_inventory.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_inventory.xml
@@ -883,7 +883,7 @@
 	</string>
 	
 	<string id="st_ui_scopes">
-		<text>Scopes</text>
+		<text>Scopes and Kits</text>
 	</string>
 	<string id="st_ui_silencer">
 		<text>Silencer</text>


### PR DESCRIPTION
While most of the weapon attachments in the game are currently scopes, there are a few that are not. This simple label change accommodates both what's currently in the game and what might be added in the future.