### PR TITLE
grok_no_npc_friendly_fire mutant hit error fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. No NPC Friendly Fire/gamedata/scripts/grok_no_npc_friendly_fire.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. No NPC Friendly Fire/gamedata/scripts/grok_no_npc_friendly_fire.script
@@ -2,11 +2,13 @@ function npc_on_before_hit(npc,shit,bone_id,flags)
     if shit.draftsman:id() == db.actor:id() then return end
 	
 	if npc then 
-		victim_comm = npc:character_community()
+		victim_comm = character_community(npc)
+		if victim_comm == "monster" then return false end
 	end
 
 	if shit.draftsman then
-		shooter_comm = shit.draftsman:character_community()
+		shooter_comm = character_community(shit.draftsman)
+		if shooter_comm == "monster" then return false end
 	end
 
 	if victim_comm and shooter_comm then


### PR DESCRIPTION
Fix for the following error occuring when one of the NPCs is a mutant:
! [LUA] CharacterCommunity available only for InventoryOwner
! [LUA]  0 : [C  ] character_community
! [LUA]  1 : [Lua] ...bin/..\gamedata\scripts\grok_no_npc_friendly_fire.script(9) : func_or_userdata