### PR TITLE
Enhanced Recoil hotfix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -192,7 +192,7 @@ options = {
 
 		{ id= "animations"	           ,type= "check"    ,val= 1	,def= true },
 		{ id= "item_swap_animation"	   ,type= "check"    ,val= 1	,def= true },
-		--{ id= "shoot_effects"	       ,type= "check"    ,val= 1	,def= false },
+		{ id= "shoot_effects"	       ,type= "check"    ,val= 1	,def= false },
 		
 		--{ id= "radiation_effect"	   ,type= "check"    ,val= 1	,def= true },
 		{ id= "blood_splash"	       ,type= "check"    ,val= 1	,def= false },


### PR DESCRIPTION
Somehow removing the option forces the parameter value to true
Would be better to just add safe checks in actor_effects at some point