### PR TITLE
M98B Reanimation for DX9/DX8

### DIFF
--- a/G.A.M.M.A/modpack_data/modpack_maker_list.txt
+++ b/G.A.M.M.A/modpack_data/modpack_maker_list.txt
@@ -412,7 +412,7 @@ https://www.moddb.com/addons/start/268102	Renegades_fixed_guns_ports_1_2\mods\2_
 https://www.moddb.com/addons/start/265945	0	 - RavenAscendant	 Busyhands Detection and Blame	https://www.moddb.com/mods/stalker-anomaly/addons/watch-dog-script
 https://www.moddb.com/addons/start/249795	00. Milspec PDA with Kill Tracker (required)	 - Catspaw	 Milspec PDA	https://www.moddb.com/mods/stalker-anomaly/addons/milspec-pda-for-anomaly-151-152-and-gamma
 https://www.moddb.com/addons/start/277063	Alternative_Pseudogiants\01 Meshes:Alternative_Pseudogiants\02 2k Textures	 - KynesPeace	 Alternative Pseudogiants	https://www.moddb.com/mods/stalker-anomaly/addons/alternative-pseudogiants
-https://www.moddb.com/addons/start/277049	M98B Reanimation\M98B Reanimation Mod:M98B Reanimation\M98B 3DSS	 - frostychun	 M98B Reanimation	https://www.moddb.com/mods/stalker-anomaly/addons/m98b-reanimation-for-gamma
+https://www.moddb.com/addons/start/277049	M98B Reanimation\M98B Reanimation Mod	 - frostychun	 M98B Reanimation	https://www.moddb.com/mods/stalker-anomaly/addons/m98b-reanimation-for-gamma
 https://www.moddb.com/addons/start/261372	Better Devices:extras\beef_nvg_anim_fix	 - BarryBogs	 Devices of Anomaly Redone	https://www.moddb.com/mods/stalker-anomaly/addons/devices-of-anomaly-redone
 https://www.moddb.com/addons/start/251981	NERFS\Main:NERFS\Modules\ARFS DLTX	 - Catspaw	 New Extensible RF Sources	https://www.moddb.com/mods/stalker-anomaly/addons/new-extensible-rf-sources
 https://www.moddb.com/addons/start/235156	0	 - HarukaSai	 Dynamic Icons Indicators	https://www.moddb.com/mods/stalker-anomaly/addons/dynamic-icon-indicators


### PR DESCRIPTION
Removes the 3DSS option from moddb Reanimation for non-DX11 users.
Don't worry git reanimation still works with 3DSS by default