### PR TITLE
Inventory script fixes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/utils_ui.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/utils_ui.script
@@ -115,7 +115,7 @@ end
 show_full_stats = false
 
 function on_key_press(key)
-	if ui_inventory.GUI then
+	if _GUIs["UIInventory"] then
 		if (key == bind_to_dik(key_bindings.kCROUCH)) then
 			--printf("full stats")
 			show_full_stats = true
@@ -125,12 +125,10 @@ function on_key_press(key)
 end
 
 function on_key_release(key)
-	if ui_inventory.GUI then
-		if (key == bind_to_dik(key_bindings.kCROUCH)) then
-			--printf("full stats")
-			show_full_stats = false
-			update_gui(ui_inventory.GUI)
-		end
+	if (key == bind_to_dik(key_bindings.kCROUCH)) then
+		--printf("full stats")
+		show_full_stats = false
+		update_gui(ui_inventory.GUI)
 	end
 end
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Press Key to Drop Item/gamedata/scripts/grok_drop_item_press_key_mcm.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Press Key to Drop Item/gamedata/scripts/grok_drop_item_press_key_mcm.script
@@ -89,7 +89,7 @@ local function ui_close()
 end
 
 local function ui_open()
-	if ui_inventory.GUI and ui_inventory.GUI.mode == "inventory" then
+	if _GUIs["UIInventory"] then
 		obj_to_drop = nil
 		register = true
 	else


### PR DESCRIPTION
`ui_inventory.GUI` appears to be always `true`, checking `_GUIs["UIInventory"]` from `_g.script` instead seems to work properly