### PR TITLE
Settings menu tweaks pt.2

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_ui_options_gamma.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_ui_options_gamma.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="windows-1251"?>
 <string_table>
+	<string id="ui_mm_desc_master_volume">
+		<text>SFX Volume setting acts as a modifier to sound's base volume attribute, meaning sounds with maximum base volume (like gunfire) will be unaffected by values higher than 0.5</text>
+	</string>
 	<string id="ui_mm_desc_zcp_settings_hint">
 		<text>Stalker and mutant population settings available in Mod Configuration Menu/ZCP</text>
 	</string>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_ui_options_gamma.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/eng/ui_st_ui_options_gamma.xml
@@ -6,6 +6,9 @@
 	<string id="ui_mm_desc_ssfx_settings_hint">
 		<text>More visual settings available in Mod Configuration Menu/SSS Settings</text>
 	</string>
+	<string id="ui_mm_desc_fft_settings_hint">
+		<text>More fast travel settings available in Mod Configuration Menu/Fair Fast Travel</text>
+	</string>
 	<string id="ui_mm_desc_aa_3dss_settings_hint">
 		<text>In-game anti-aliasing and SMAA settings are incompatible with 3D Shader Scopes.\nUse your GPU control panel anti-aliasing or adjust scope resolution in Mod Configuration Menu/3D Scopes</text>
 	</string>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/rus/ui_st_ui_options_gamma.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/rus/ui_st_ui_options_gamma.xml
@@ -6,6 +6,9 @@
 	<string id="ui_mm_desc_ssfx_settings_hint">
 		<text>Больше настроек видео ищите в МЕНЮ МСМ/SSS Настройки</text>
 	</string>
+	<string id="ui_mm_desc_fft_settings_hint">
+		<text>Больше настроек быстрого перемещения ищите в МЕНЮ МСМ/Fair Fast Travel</text>
+	</string>
 	<string id="ui_mm_desc_aa_3dss_settings_hint">
 		<text>Внутриигровые настройки сглаживания и SMAA несовместимы с 3D Shader Scopes.\nИспользуйте сглаживание в панели управления видеокарты или настройте разрешение прицела в МЕНЮ МСМ/3D Scopes</text>
 	</string>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/rus/ui_st_ui_options_gamma.xml
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/configs/text/rus/ui_st_ui_options_gamma.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="windows-1251"?>
 <string_table>
+	<string id="ui_mm_desc_master_volume">
+		<text>Параметр общей громкости это модификатор базовой громкости звука, поэтому изменение значения выше 0.5 не повлияют на звуки с максимальной базовой громкостью (например звуки стрельбы)</text>
+	</string>
 	<string id="ui_mm_desc_zcp_settings_hint">
 		<text>Настройки популяции сталкеров и мутантов ищите в МЕНЮ МСМ/ZCP</text>
 	</string>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -248,6 +248,7 @@ options = {
 	{ id= "general"      	,sh=true ,gr={
 		{ id= "slide_sound"				,type= "slide"	  ,link= "ui_options_slider_sound"	 ,text= "ui_mm_title_sound"		,size= {512,50}		},
 
+		{ id= "desc_master_volume"    	,type= "desc"     ,text= "ui_mm_desc_master_volume"			 	,clr= {255,125,175,200}	},
 		{ id= "master_volume"           ,type= "track"    ,val= 2	,cmd= "snd_volume_eff"	            ,min= 0   ,max= 1   ,step= 0.1                 },
 		{ id= "music_volume"            ,type= "track"    ,val= 2	,cmd= "snd_volume_music"	        ,min= 0   ,max= 1   ,step= 0.1                 },
 		{ id= "sound_device"            ,type= "list"     ,val= 0	,cmd= "snd_device"					,no_str= true            	,restart= true     },

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -299,7 +299,7 @@ options = {
 		{ id= "outfit_portrait"    	 	 ,type= "check"    ,val= 1	,def= true	 },
 		{ id= "hardcore_ai_aim"          ,type= "check"    ,val= 1	,def= false	 ,functor= {func_hardcore_ai_aim}   },
 		{ id= "show_tip_reputation"    	 ,type= "check"    ,val= 1	,def= true	 },
-		--{ id= "mechanic_feature"    	 ,type= "check"    ,val= 1	,def= false	 },
+		{ id= "mechanic_feature"    	 ,type= "check"    ,val= 1	,def= false	 },
 		
 		{ id= "line"				 	 ,type= "line"		},
 		{ id= "release_dropped_items"    ,type= "check"    ,val= 1	,def= true	 },

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -92,7 +92,7 @@ options = {
 		{ id= "gamma"  		           ,type= "track"    ,val= 2	,cmd= "rs_c_gamma"					,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
 		{ id= "contrast"  	           ,type= "track"    ,val= 2	,cmd= "rs_c_contrast"				,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
 		{ id= "brightness"             ,type= "track"    ,val= 2	,cmd= "rs_c_brightness"				,min= 0.5  ,max= 1.5  ,step= 0.1 ,precondition= {for_renderer,"renderer_r1"}	},
-		{ id= "fov"  		           ,type= "track"    ,val= 2	,cmd= "fov"							,min= 5    ,max= 180  ,step= 1 },
+		{ id= "fov"  		           ,type= "track"    ,val= 2	,cmd= "fov"							,min= 5    ,max= 150  ,step= 1 },
 		{ id= "hud_fov"  	           ,type= "track"    ,val= 2	,cmd= "hud_fov"						,min= 0.1  ,max= 1    ,step= 0.01 },
 		{ id= "screen_mode"            ,type= "radio_h"  ,val= 2	,curr= {curr_screen_mode} 			,content= {{1,"fullscreen"} , {2,"borderless"} , {3,"windowed"}} 	,functor = {func_screen_mode}		},
 		{ id= "lighting"  		       ,type= "button"   ,functor_ui= {start_lighting_ui}  				,precondition= {level_present}		,precondition_1= {for_renderer,"renderer_r2a","renderer_r2","renderer_r2.5","renderer_r3","renderer_r4"}    },
@@ -299,7 +299,7 @@ options = {
 		{ id= "outfit_portrait"    	 	 ,type= "check"    ,val= 1	,def= true	 },
 		{ id= "hardcore_ai_aim"          ,type= "check"    ,val= 1	,def= false	 ,functor= {func_hardcore_ai_aim}   },
 		{ id= "show_tip_reputation"    	 ,type= "check"    ,val= 1	,def= true	 },
-		{ id= "mechanic_feature"    	 ,type= "check"    ,val= 1	,def= false	 },
+		--{ id= "mechanic_feature"    	 ,type= "check"    ,val= 1	,def= false	 },
 		
 		{ id= "line"				 	 ,type= "line"		},
 		{ id= "release_dropped_items"    ,type= "check"    ,val= 1	,def= true	 },
@@ -393,6 +393,7 @@ options = {
 	{ id= "fast_travel"     ,sh=true ,gr={
 		{ id= "slide_fast_travel"		,type= "slide"	  ,link= "ui_options_slider_fast_travel"	 ,text= "ui_mm_menu_fast_travel"		,size= {512,50}		},
 		{ id= "desc_fast_travel"    	,type= "desc"     ,text= "ui_mm_desc_fast_travel"			 ,clr= {255,125,175,200}	},
+		{ id= "fft_settings_hint"    	,type= "desc"     ,text= "ui_mm_desc_fft_settings_hint"		 ,clr= {255,125,175,200}				,precondition = {catsy_fftd_mcm}	},
 		{ id= "line"					,type= "line"	  },
 		
 		{ id= "state"  					,type= "list"     ,val= 2   ,def= 0 	 ,content= {{0,"disabled"} , {1,"visit_only"} , {2,"show_all"}}		},
@@ -821,6 +822,14 @@ function smr_mutants_mcm_disabled()
 end
 function smr_mcm_enabled()
 	if smr_stalkers_mcm or smr_mutants_mcm then
+		return true
+	else
+		return false
+	end
+end
+
+function catsy_fftd_mcm()
+	if catsy_fftd_mcm then
 		return true
 	else
 		return false

--- a/G.A.M.M.A/modpack_addons/ZCP 1.5d/gamedata/scripts/smr_loot_mcm.script
+++ b/G.A.M.M.A/modpack_addons/ZCP 1.5d/gamedata/scripts/smr_loot_mcm.script
@@ -49,7 +49,7 @@ function on_mcm_load()
         { id="ammo_spawn", type="check", val=1, def=false},
         { id="ammo_chance", type="track", val=2, min=1, max=100, step=1, def=20 },
         { id="ammo_amount", type="track", val=2, min=0.1, max=3, step=0.1, def=1 },
-        { id="ammo_bad_spawn", type="check", val=1, def=true},
-        { id="ammo_bad_chance", type="track", val=2, min=1, max=100, step=1, def=50 },
+        -- { id="ammo_bad_spawn", type="check", val=1, def=true},
+        -- { id="ammo_bad_chance", type="track", val=2, min=1, max=100, step=1, def=50 },
     }}, "SMR"
 end


### PR DESCRIPTION
- Limited FOV slider: ~160 degrees break camera completely
- ~~Removed "Delayed repairs at mechanics": redundant/may cause repaired item to be lost~~
- Removed ZCP "Old ammo spawn": incompatible with BAS
- Fair Fast Travel MCM hint added
- SFX Volume description added