### PR TITLE
wpn_trg_hud crash fix

### DIFF
--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -18,7 +18,6 @@
 -Apathy's Better Detector Position
 -379- Get out of my way you stupid NPC - NewbieRus
 -376- Barbed Wire Shadow Fix - VodkaPivin
--352- SV98 Reanimation - NickolasNikova
 -342- Desert Eagle Gunslinger Port - Dizmok & Pieuvre
 -305- Dux Characters Kit Voices Pack - Demonized
 -273- Longreed's fixed artefacts spawns under maps - Longreed
@@ -328,6 +327,7 @@
 +355- Steyr Scout - JMerc75
 +354- AK12 Reanimation - SeDzhiMol
 +353- RPD Reanimation - NickolasNikova
++352- SV98 Reanimation - NickolasNikova
 +351- M249 Reanimation - NickolasNikova
 +350- Ledge Grabbing - Demonized
 +349- Hideout Furniture Expansion - Maid & HarukaSai


### PR DESCRIPTION
Re-enable SV98 Reanimation since 3DSS uses its Sako TRG animations. Other files are overwritten.
Also useful for DX8/DX9 players