### PR TITLE
Nimble weapon upgrade fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/Darkasleif's Nimble Upgrades Guns/gamedata/scripts/NimbleTrade.script
+++ b/G.A.M.M.A/modpack_addons/Darkasleif's Nimble Upgrades Guns/gamedata/scripts/NimbleTrade.script
@@ -20,7 +20,7 @@ UrbanaCost = 45000
 SaboteurCost = 45000
 SVUCost = 45000
 
-local gun_val = 0.9 --Ranges from 0-1. Currently set to 90%.
+local gun_val = 0.01 --Ranges from 0-1. Currently set to 1%.
 local part_val = 90 --Ranges from 0-100. Currently set to 90%.
 
 --====================< Definitions >====================--


### PR DESCRIPTION
Changes script weapon condition value to 1% such that Nimble takes weapons for upgrades (since weapon condition is fixed). Leaves gun part condition unchanged.