### PR TITLE
3DSS PKM SpecterDR scope fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/410- 3DSS for GAMMA - Redotix99 & Andtheherois & party50/gamedata/configs/mod_system_zzzzz_3ds_gamma_rifles.ltx
+++ b/G.A.M.M.A/modpack_addons/410- 3DSS for GAMMA - Redotix99 & Andtheherois & party50/gamedata/configs/mod_system_zzzzz_3ds_gamma_rifles.ltx
@@ -2557,8 +2557,8 @@ scope_texture                    =
 
 s3ds_exit_pupil		= 0.4
 ![wpn_pkm_zenit_siber_specter_hud]
-        aim_hud_offset_pos               = 0.007058, -0022065, -0.043522
-        aim_hud_offset_pos_16x9          = 0.007058, -0022065, -0.043522
+        aim_hud_offset_pos               = 0.007058, -0.022065, -0.043522
+        aim_hud_offset_pos_16x9          = 0.007058, -0.022065, -0.043522
         aim_hud_offset_rot               = 0.007856, 0.002285, 0.009321
         aim_hud_offset_rot_16x9          = 0.007856, 0.002285, 0.009321
 		


### PR DESCRIPTION
Added missing decimal point to y-position of PKM aim down sight for SpecterDR scope.