### PR TITLE
Fixed MP155 sprint transition

### DIFF
--- a/G.A.M.M.A/modpack_addons/41- LowerSprintAnimaiton - Skieppy/gamedata/scripts/lower_weapon_sprint.script
+++ b/G.A.M.M.A/modpack_addons/41- LowerSprintAnimaiton - Skieppy/gamedata/scripts/lower_weapon_sprint.script
@@ -190,7 +190,7 @@ exclude["wpn_fn2000"] = 182
 exclude["wpn_fn2000_camo"] = 183
 exclude["wpn_fn2000_custom"] = 184
 exclude["wpn_fn2000_nimble"] = 185
-exclude["wpn_mp155"] = 186	-- some transition seems to be glitched
+-- exclude["wpn_mp155"] = 186	-- sprint breaks if un-commented
 exclude["wpn_colt1911_n"] = 187
 
 local function is_excluded(sec)

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_zzz_tcwp_fixes_GAMMA.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_zzz_tcwp_fixes_GAMMA.ltx
@@ -15,6 +15,7 @@ anm_idle_sprint                 = mp155_new_sprint, idle, 1.2
 anm_idle_sprint_empty           = mp155_new_sprint, idle_empty, 1.2
 anm_idle_sprint_jammed          = mp155_new_sprint, idle_jammed, 1.2
 
+ts_pattern_sprint_start         = .+, anm_idle_sprint, 1
 ; !ts_pattern_sprint_end
 
 ; !anm_sprint_end


### PR DESCRIPTION
I am assuming this is how you fix code from mods after extraction, if not let me know how to do it the correct way. 

w_mp155.ltx is copied from Covenant Weapon Pack 3DSS with an additional line that includes ts_pattern_sprint_start.  Commented out MP155 from lower weapon script blacklist.