### PR TITLE
LOD Compatability moved in mod load order

### DIFF
--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -82,10 +82,10 @@
 +287- G.A.M.M.A. Massive Text Overhaul Project - SageDaHerb and Dr.Pr1nkos
 +G.A.M.M.A. Short Psi Storms
 +290- Atmospherics Shaders Weathers and Reshade Latest - Hippobot
++388- Aydins Grass Tweaks SSS Terrain LOD Compatibility - aytabag
 +190- Screen Space Shaders 20 - Ascii1457
 +189- Beef's NVG - theRealBeef
 +188- Enhanced Shaders - KennShade
-+388- Aydins Grass Tweaks SSS Terrain LOD Compatibility - aytabag
 +289- Grass Tweaks (reinstall for different options) - Aydin
 +410- 3DSS for GAMMA - Redotix99 & Andtheherois & party50
 +436- Alpha AKM Reanimation - SeDzhiMol


### PR DESCRIPTION
Changed load order to fix terrain LOD issues, could require clearing of shader cache.

Load order now:
Grass Tweaks - Aydin
SSS
LOD Compatibility