### PR TITLE
Fix M249 Specter scope

### DIFF
--- a/G.A.M.M.A/modpack_addons/410- 3DSS for GAMMA - Redotix99 & Andtheherois & party50/gamedata/configs/mod_system_zzzzz_3ds_gamma_rifles.ltx
+++ b/G.A.M.M.A/modpack_addons/410- 3DSS for GAMMA - Redotix99 & Andtheherois & party50/gamedata/configs/mod_system_zzzzz_3ds_gamma_rifles.ltx
@@ -2383,6 +2383,7 @@ scope_status                 = 1
 scope_texture                = 
 scope_zoom_factor            = 30
 scope_dynamic_zoom		     = on
+zoom_step_count=1
 
 [wpn_m249_specter_hud]:wpn_m249_hud,hud_low_interia
 item_visual                              = anomaly_weapons\wpn_m249\wpn_m249_specter_hud.ogf


### PR DESCRIPTION
Made it so that there are only two zoom options so the scope cannot be in the "inbetween" zoom options.