### PR TITLE
Crafting missing component sprt_o_retardant_19 fixes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
@@ -186,7 +186,7 @@ x_upgr_o_2_carry            = 2, recipe_advanced_3,prt_o_ballistic_14,2,prt_o_ba
 x_upgr_o_3_carry            = 3, recipe_expert_3,prt_o_ballistic_14,3,prt_o_ballistic_16,3,prt_i_scrap,4,prt_i_fasteners,4
 
 x_upgr_o_1_arty             = 1, recipe_basic_3,prt_o_retardant_19,1,prt_o_retardant_12,1,prt_o_fabrics_3,2,prt_i_scrap,3
-x_upgr_o_2_arty             = 2, recipe_advanced_3,sprt_o_retardant_19,2,prt_o_retardant_12,2,prt_o_fabrics_3,3,prt_i_scrap,5
+x_upgr_o_2_arty             = 2, recipe_advanced_3,prt_o_retardant_19,2,prt_o_retardant_12,2,prt_o_fabrics_3,3,prt_i_scrap,5
 x_upgr_o_3_arty             = 3, recipe_expert_3,prt_o_retardant_19,3,prt_o_retardant_12,3,prt_o_fabrics_3,4,prt_i_scrap,7
 
 x_upgr_o_1_run              = 1, recipe_basic_3,prt_i_copper,8,prt_i_transistors,8,prt_i_capacitors,8,prt_i_fasteners,8

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Arti Recipes Overhaul/gamedata/configs/items/settings/craft.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Arti Recipes Overhaul/gamedata/configs/items/settings/craft.ltx
@@ -151,7 +151,7 @@ x_upgr_o_2_carry            = 2, recipe_advanced_0,prt_o_ballistic_14,2,prt_o_ba
 x_upgr_o_3_carry            = 3, recipe_expert_0,prt_o_ballistic_14,3,prt_o_ballistic_16,3,prt_i_scrap,4,prt_i_fasteners,4
 
 x_upgr_o_1_arty             = 1, recipe_basic_0,lead_box,1,prt_o_retardant_19,1,prt_o_retardant_12,1,prt_o_fabrics_3,2
-x_upgr_o_2_arty             = 2, recipe_advanced_0,lead_box,2,sprt_o_retardant_19,2,prt_o_retardant_12,2,prt_o_fabrics_3,3
+x_upgr_o_2_arty             = 2, recipe_advanced_0,lead_box,2,prt_o_retardant_19,2,prt_o_retardant_12,2,prt_o_fabrics_3,3
 x_upgr_o_3_arty             = 3, recipe_expert_0,lead_box,3,prt_o_retardant_19,3,prt_o_retardant_12,3,prt_o_fabrics_3,4
 
 x_upgr_o_1_run              = 1, recipe_basic_0,prt_i_copper,8,prt_i_transistors,8,prt_i_capacitors,8,prt_i_fasteners,8


### PR DESCRIPTION
`sprt_o_retardant_19` is referenced, but this does not exist.