### PR TITLE
Remove Universal Weapon Kit from quest packages

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/configs/items/settings/mod_itms_manager_remove_universal_kits.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/configs/items/settings/mod_itms_manager_remove_universal_kits.ltx
@@ -1,0 +1,4 @@
+![package_content]
+<quest_package_6     = cleaning_kit_u
+<quest_package_7     = cleaning_kit_u
+<quest_package_8     = cleaning_kit_u


### PR DESCRIPTION
DLTX patch to remove cleaning_kit_u from quest_package_6, quest_package_7, quest_package_8