### PR TITLE
Fix trade_monolith_basic supply level goodwill using bandit faction goodwill. Courtesy of zodium and veerserif

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_monolith_basic.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy/gamedata/configs/items/trade/trade_monolith_basic.ltx
@@ -5,7 +5,7 @@
 [trader]
 buy_condition = trade_generic_buy
 sell_condition = trade_generic_sell
-buy_supplies = {=actor_goodwill_ge(bandit:2000)} supplies_5, {=heavy_pockets_functor()} supplies_5, {=actor_goodwill_ge(bandit:1500)} supplies_4, {=actor_goodwill_ge(bandit:1000)} supplies_3, {=actor_goodwill_ge(bandit:500)} supplies_2,  supplies_1
+buy_supplies = {=actor_goodwill_ge(monolith:2000)} supplies_5, {=heavy_pockets_functor()} supplies_5, {=actor_goodwill_ge(monolith:1500)} supplies_4, {=actor_goodwill_ge(monolith:1000)} supplies_3, {=actor_goodwill_ge(monolith:500)} supplies_2,  supplies_1
 buy_item_condition_factor = 0.05
 buy_item_exponent = 2.25
 sell_item_exponent = 0.75


### PR DESCRIPTION
trade_monolith_basic is used by NPCs:
- trader_monolith_kbo - Outskirts Monolith Trader named Olivar
- monolith_bridge_trader_mlr - Bridge to Limansk Monolith Trader with random stalker name - this NPC spawn looks to be disabled.