### PR TITLE
Fix expert and professional ecologists using identical selection of primary weapons as novice ecologists

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_ecolog.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_ecolog.ltx
@@ -20,10 +20,8 @@ secondary = ecolog_stalker_secondary
 [ecolog_trainee]:ecolog_novice
 
 [ecolog_professional]:ecolog_experienced
-primary = ecolog_nstalker_primary
 
 [ecolog_expert]:ecolog_veteran
-primary = ecolog_stalk_seva_primary
 
 [ecolog_legend]:ecolog_master
 
@@ -282,7 +280,7 @@ wpn_sr1m:r:0:60
 wpn_mp412:r:0:10
 wpn_pl15_tan:r:0:25
 
-[ecolog_nstalker_primary]
+[ecolog_nstalker_primary] ; Unused
 wpn_bizon:0:0:10
 wpn_kiparis:0:0:30
 wpn_vityaz:0:0:30
@@ -317,7 +315,7 @@ wpn_ak74m_beard:r:0:3
 wpn_ak74u_tac:r:0:3
 wpn_toz34_mark4_23:0:0:1
 
-[ecolog_stalk_seva_primary]
+[ecolog_stalk_seva_primary] ; Unused
 wpn_bizon:0:0:10
 wpn_kiparis:0:0:30
 wpn_vityaz:0:0:30


### PR DESCRIPTION
Both expert and professional ecologist primary gun sections are overwritten by what look like some leftovers of an armour-based loadout idea, but even Vanilla Anomaly ecologists character_desc file and their respective ranks aren't set up for this. In GAMMA this is further changed by both Dux's Character Kit (changing what visuals are used at what tier) and Improved Ranks (changing what tier of npc is at what rank).

This change removes the overwrite of those primary sections so now expert ecologists use same primary as veteran and professional ecologists use same primary as experienced.

Comparison of novice, professional and expert ecologists primary loadout sections:
![image](https://github.com/user-attachments/assets/4a47466e-fcc0-44eb-b871-f4e793484153)