### PR TITLE
Fix triple af_monolith_absorbation overwrite in Artefacts Reinvention DLTX file. Credit to zodium for discovering the issue

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/mod_system_zzzzzzzzzzzzzzzzz_grok_artifacts.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/mod_system_zzzzzzzzzzzzzzzzz_grok_artifacts.ltx
@@ -553,7 +553,7 @@ telepatic_cap = 0.10
 additional_inventory_weight	= 15
 additional_inventory_weight2 = 15
 bleeding_restore_speed = 0.00612
-![af_monolith_absorbation]:af_base_absorbation
+![af_ah_f1_absorbation]:af_base_absorbation
 burn_immunity = 0
 shock_immunity = 0
 telepatic_immunity = 0.165
@@ -572,7 +572,7 @@ radiation_restore_speed                          = 0.00
 bleeding_restore_speed = 0.00612
 health_restore_speed = 0.0006
 burn_cap = 0.15
-![af_monolith_absorbation]:af_base_absorbation
+![af_tlf_prometheus_absorbation]:af_base_absorbation
 burn_immunity = 0.41
 shock_immunity = 0
 telepatic_immunity = 0


### PR DESCRIPTION
![af_monolith_absorbation] section was present after

af_monolith
af_ah_f1
af_tlf_prometheus

This caused actual af_monolith_absorbation be the one after af_tlf_prometheus, likely using the resistance values meant for af_tlf_prometheus.