### PR TITLE
To prevent stutters, always resupply traders no matter the distance

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/scripts/trader_autoinject.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/scripts/trader_autoinject.script
@@ -45,8 +45,6 @@ function trade_manager.update(npc, force_refresh)
     if not npc or not npc:alive() then
         return
     end
-    -- sid/forester fix - check if close by and then run
-    if furniture[npc:name()] and npc:position():distance_to(db.actor:position()) > 20 then return end
     
     local reup_time = trade_manager.get_trade_profile(id, "resupply_time")
     TraderUpdate(npc, force_refresh)


### PR DESCRIPTION
I'm not sure what the original fix was doing, but it was causing many items to be spawned on a trader the first time when the player gets close enough which causes a pretty significant long stutter. The change allows these items to be spawned in as soon as possible rather than wait for the player to get close; preferrable these items will spawn as soon as the player loads in the level.

You can reproduce the stutter by booting up a fresh new game and starting in Cordon Village and then walking over to Sidorovich. You will get a stutter outside the fence that leads to Sidorovich's entrance.

The stuttering is not so much the act of spawning the items, but the need to load in-game assets at the time of spawn. If the assets have been loaded, then there wouldn't be a stutter when the items get spawned.