### PR TITLE
Carry weight ui elements show one decimal point.

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/utils_ui.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/utils_ui.script
@@ -2807,10 +2807,19 @@ function UIInfoItem:Update(obj, sec, flags)
 					local valbar_a = val_a * gr.magnitude
 					local unit = gr.unit and gr.unit ~= "" and game.translate_string(gr.unit) or ""
 					local clr = valbar_a >= 0 and clr_list["p1"] or clr_list["n1"]
+					
+					if stat == "additional_inventory_weight" or stat == "boost_max_weight" then
+						valbar_a = valbar_a*10
+					end
+
 					if valbar_a >= 0 then
 						valbar_a = math.ceil(valbar_a)
 					else
 						valbar_a = math.floor(valbar_a)
+					end
+
+					if stat == "additional_inventory_weight" or stat == "boost_max_weight" then
+						valbar_a = valbar_a/10
 					end
 					
 					if gr.sign_inverse then


### PR DESCRIPTION
Gun weight and player carry weight already have one decimal point so this is in line with other weight ui displays. Would also make carry weight adjustments more readable.