### PR TITLE
"Ball" perkifact has the better PBA 2.1 functionality + possible "Chain" crash fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/287- G.A.M.M.A. Massive Text Overhaul Project - SageDaHerb and Dr.Pr1nkos/gamedata/configs/text/eng/st_perk_based_artefacts_perks.xml
+++ b/G.A.M.M.A/modpack_addons/287- G.A.M.M.A. Massive Text Overhaul Project - SageDaHerb and Dr.Pr1nkos/gamedata/configs/text/eng/st_perk_based_artefacts_perks.xml
@@ -6,249 +6,256 @@
   <string id="st_pba_af_cocoon_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]STONE SKIN\n 
-    %c[0,81,63,22] • %c[0,209,172,56]Passive +15% melee damage protection\n
-    %c[0,81,63,22] • %c[0,209,172,56]Receiving melee damage grants a stack of 'Stone Skin'\n
-    %c[0,81,63,22] • %c[0,209,172,56]+15% melee damage protection/-10% movement speed per 'Stone Skin' stack\n
-    %c[0,81,63,22] • %c[0,209,172,56]Maximum 10 stacks\n
-    %c[0,81,63,22] • %c[0,209,172,56]At 10 stacks, +75% melee damage reduction but become completely immobilized\n
-    %c[0,81,63,22] • %c[0,209,172,56]Effect lasts 10 seconds, after which all stacks are removed\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Passive +15% melee damage protection\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Receiving melee damage grants a stack of 'Stone Skin'\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]+15% melee damage protection/-10% movement speed per 'Stone Skin' stack\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Maximum 10 stacks\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]At 10 stacks, +75% melee damage reduction but become completely immobilized\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Effect lasts 10 seconds, after which all stacks are removed\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_cell_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]DISINTEGRATOR\n
-    %c[0,81,63,22] • %c[0,209,172,56]-15% bullet damage received\n
-    %c[0,81,63,22] • %c[0,209,172,56]Reduced damage is converted to radiation\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]-15% bullet damage received\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Reduced damage is converted to radiation\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_fountain_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]LETYSHOPS TIME\n
-    %c[0,81,63,22] • %c[0,209,172,56]Receive 4% cashback on each purchase\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Receive 4% cashback on each purchase\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_spaika_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]CRITICAL ASCENSI0N\n
-    %c[0,81,63,22] • %c[0,209,172,56]Passive +10% critical hit damage bonus\n
-    %c[0,81,63,22] • %c[0,209,172,56]Consecutive hits grant stacks of 'Critical Ascensi0n'\n
-    %c[0,81,63,22] • %c[0,209,172,56]Each stack of 'Critical Ascensi0n' grants +5% damage to next shot\n
-    %c[0,81,63,22] • %c[0,209,172,56]Missing a shot removes all stacks and gives psy damage proportional to the amount of stacks removed\n
-    %c[0,81,63,22] • %c[0,209,172,56]Bonus can be stacked infinitely as long as you don't miss\n
-    %c[0,81,63,22] • %c[0,209,172,56]Unequipping all 'Spike' artefacts will remove stacks without penalty\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Passive +10% critical hit damage bonus\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Consecutive hits grant stacks of 'Critical Ascensi0n'\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Each stack of 'Critical Ascensi0n' grants +5% damage to next shot\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Missing a shot removes all stacks and gives psy damage proportional to the amount of stacks removed\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Bonus can be stacked infinitely as long as you don't miss\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Unequipping all 'Spike' artefacts will remove stacks without penalty\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_signet_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]LIGHT OF TRANQUILITY\n
-    %c[0,81,63,22] • %c[0,209,172,56]Restores health and psy health while near campfires\n
-    %c[0,81,63,22] • %c[0,209,172,56]Amplifies psy recovery artefacts while near campfires\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Restores health and psy health while near campfires\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Amplifies psy recovery artefacts while near campfires\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_repei_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]MINOR LACERATIONS\n
-    %c[0,81,63,22] • %c[0,209,172,56]Your weapon loses 50% damage but gains the ability to cause %c[ui_red]bleeding %c[0,209,172,56]damage\n
-    %c[0,81,63,22] • %c[0,209,172,56]Bleeding damage is proportional to weapon damage\n
-    %c[0,81,63,22] • %c[0,209,172,56]Increases chance for enemies to surrender\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Your weapon loses 50% damage but gains the ability to cause %c[ui_red]bleeding %c[0,209,172,56]damage\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Bleeding damage is proportional to weapon damage\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Increases chance for enemies to surrender\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
   </text>
   </string>
   <string id="st_pba_af_bat_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]ZONE ALCHEMY\n
-    %c[0,81,63,22] • %c[0,209,172,56]Grants the ability to transmutate artefacts\n
-    %c[0,81,63,22] • %c[0,209,172,56]Artefacts can be upgraded to a better tier (Night Star -> Gravi -> Gold Fish), or "mutated" to a different artifact of the same tier (Night Star -> Stone Blood -> Jellyfish)\n
-    %c[0,81,63,22] • %c[0,209,172,56]Perk/Top-tier artefacts can only be mutated\n
-    %c[0,81,63,22] • %c[0,209,172,56]Each transmutation will consume one 'Bat' artefact\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Grants the ability to transmutate artefacts\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Artefacts can be upgraded to a better tier (Night Star -> Gravi -> Gold Fish), or "mutated" to a different artifact of the same tier (Night Star -> Stone Blood -> Jellyfish)\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Perk/Top-tier artefacts can only be mutated\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Each transmutation will consume one 'Bat' artefact\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_sun_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]SOLAR POWERED\n
-    %c[0,81,63,22] • %c[0,209,172,56]Grants stat modifiers depending on the current weather:\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Grants stat modifiers depending on the current weather:\n
 	%c[0,209,172,56] --- Clear: health and stamina boost\n
 	%c[0,209,172,56] --- Partly Clear: small stamina boost\n
 	%c[0,209,172,56] --- Other: stamina penalty\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_ear_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]WILL TO LIVE\n
-    %c[0,81,63,22] • %c[0,209,172,56]Grants health regen while under 25% health\n
-    %c[0,81,63,22] • %c[0,209,172,56]Effect increases the closer to you are to death\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Grants health regen while under 25% health\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Effect increases the closer to you are to death\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_chelust_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]WEIGHT OF DEVOTION\n
-    %c[0,81,63,22] • %c[0,209,172,56]Passive small health and stamina regen\n
-    %c[0,81,63,22] • %c[0,209,172,56]Members of Sin are granted triple the effect with the addition of psy health regeneration\n
-    %c[0,81,63,22] • %c[0,209,172,56]Sin companions receive health regen.\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Passive small health and stamina regen\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Members of Sin are granted triple the effect with the addition of psy health regeneration\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Sin companions receive health regen.\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_atom_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]ARSZI'S BLESSING\n
-    %c[0,81,63,22] • %c[0,209,172,56]Radiation illness grants a stamina boost and slight radiation removal\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Radiation illness grants a stamina boost and slight radiation removal\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_lighthouse_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]THE UNORTHODOX WAY OF TRAVELLING\n
-    %c[0,81,63,22] • %c[0,209,172,56]Killing anyone will teleport you to the location of their death\n
-    %c[0,81,63,22] • %c[0,209,172,56]Dangerous if used on airborne targets\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Killing anyone will teleport you to the location of their death\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Dangerous if used on airborne targets\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_fire_loop_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]DEAL WITH THE DEVIL\n
-    %c[0,81,63,22] • %c[0,209,172,56]Moving the artefact to the belt will sign the 'Pact with the Zone'\n\n
-	%c[0,81,63,22] • %c[ui_red]Highly recommended to save before activation.
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Moving the artefact to the belt will sign the 'Pact with the Zone'\n\n
+	%c[0,81,63,22] â€¢ %c[ui_red]Highly recommended to save before activation.
 	</text>
   </string>
   <string id="st_pba_af_zhelch_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]INSANITY\n
-    %c[0,81,63,22] • %c[0,209,172,56]Passive strong psy resistance\n
-    %c[0,81,63,22] • %c[0,209,172,56]Drains psy health to restore health\n
-    %c[0,81,63,22] • %c[0,209,172,56]When health is full, restores psy health\n
-    %c[0,81,63,22] • %c[0,209,172,56]There is a chance you will become possessed and perform an uncontrollable action\n
-    %c[0,81,63,22] • %c[0,209,172,56]The lower your psy health, the higher the chance and severity of the action\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Passive strong psy resistance\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Drains psy health to restore health\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]When health is full, restores psy health\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]There is a chance you will become possessed and perform an uncontrollable action\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]The lower your psy health, the higher the chance and severity of the action\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_sandstone_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]ZONE INFUSION\n
-    %c[0,81,63,22] • %c[0,209,172,56]Stepping into anomalies of various types will infuse your active weapon for 3 minutes\n
-    %c[0,81,63,22] • %c[0,209,172,56]Infused weapon loses 30% damage but gains 50% elemental damage according to the anomaly\n
-    %c[0,81,63,22] • %c[0,209,172,56]Only electric, thermal and chemical anomalies are valid for infusion\n
-    %c[0,81,63,22] • %c[0,209,172,56]You can drop an artefact directly onto a weapon to detroy the artefact and infuse the weapon with a random effect for 10 minutes.\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Stepping into anomalies of various types will infuse your active weapon for 3 minutes\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Infused weapon loses 30% damage but gains 50% elemental damage according to the anomaly\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Only electric, thermal and chemical anomalies are valid for infusion\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]You can drop an artefact directly onto a weapon to detroy the artefact and infuse the weapon with a random effect for 10 minutes.\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_kislushka_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]CALORIC COAGULATION\n
-    %c[0,81,63,22] • %c[0,209,172,56]Drains hunger to cure bleeding\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Drains hunger to cure bleeding\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_black_angel_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]DODGE THIS\n
-    %c[0,81,63,22] • %c[0,209,172,56]20% chance to reflect 35% of bullet damage recived back to the attacker\n
-    %c[0,81,63,22] • %c[0,209,172,56]Reflections nullify damage\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]20% chance to reflect 35% of bullet damage recived back to the attacker\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Reflections nullify damage\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_grapes_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]NECESSARY GLUTTONY\n
-    %c[0,81,63,22] • %c[0,209,172,56]Provides health bonus on food consumption based on calories\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Provides health bonus on food consumption based on calories\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_skull_miser_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]CRACK THE JACKPOT\n
-    %c[0,81,63,22] • %c[0,209,172,56]Upon a lethal headshot, extra money is dropped\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Upon a lethal headshot, extra money is dropped\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_star_phantom_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]PHANTOM PACIFIST\n
-    %c[0,81,63,22] • %c[0,209,172,56]Makes you completely invisible\n
-    %c[0,81,63,22] • %c[0,209,172,56]1.5 minute total duration\n
-    %c[0,81,63,22] • %c[0,209,172,56]During invisibility you may not draw a weapon, talk or 'interact'\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Makes you completely invisible\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]1.5 minute total duration\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]During invisibility you may not draw a weapon, talk or 'interact'\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_medallion_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]THE UNLUCKY CHARM\n
-    %c[0,81,63,22] • %c[0,209,172,56]35% chance that incoming bullet damage will be fully redirected to your companion\n
-    %c[0,81,63,22] • %c[0,209,172,56]May make some companions suspicious...\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]35% chance that incoming bullet damage will be fully redirected to your companion\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]May make some companions suspicious...\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_peas_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]NIGHT OWL\n
-    %c[0,81,63,22] • %c[0,209,172,56]Bleeding recovery and movement speed increase from dusk till dawn\n
-    %c[0,81,63,22] • %c[0,209,172,56]Decreases sleepiness at night but increases sleepiness during the day\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Bleeding recovery and movement speed increase from dusk till dawn\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Decreases sleepiness at night but increases sleepiness during the day\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_generator_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]CHARGER\n
-    %c[0,81,63,22] • %c[0,209,172,56]Restores batteries while sprinting\n
-    %c[0,81,63,22] • %c[0,209,172,56]Will not restore dead batteries or devices with no batteries\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Restores batteries while sprinting\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Will not restore dead batteries or devices with no batteries\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_red]YES
 	</text>
   </string>
   <string id="st_pba_af_ball_perk">
-    <text>
-    %c[0,209,172,56]Perk: %c[d_orange]THE NUTCRACKER\n
-    %c[0,81,63,22] • %c[0,209,172,56]Allows a mighty mutant kick\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+	<text>
+	%c[0,209,172,56]Perk: %c[d_orange]THE NUTCRACKER\n
+	%c[0,81,63,22]  â€¢ %c[0,209,172,56]Amplifies player's mighty foot and allows him to kick more mutants, resulting in instant death.\n
+	%c[0,81,63,22]  â€¢ %c[0,209,172,56]Each artefact on the belt allows kicking more monsters.\n
+	%c[0,81,63,22]  â€¢ %c[0,209,172,56]Has a cooldown of 2 seconds with 1 artefact, increases with more artefacts on belt by 1 second with each artefact.\n
+	%c[0,81,63,22]  â€¢ %c[0,209,172,56]Press USE key when near a mutant and in line of sight to perform a kick\n \n 
+	%c[d_orange]Mutant tiers: \n
+		%c[0,192,71,221] -   1 artefact: %c[ui_gray_3]Cats, Dogs, Tushkano, Rats, Zombies.\n
+		%c[0,192,71,221] -   2 artefacts: %c[ui_gray_3]Boars, Flesh, Pseudodogs, Snorks, Lurkers, Fractures.\n
+		%c[0,192,71,221] -   3 artefacts: %c[ui_gray_3]Karliks, Bloodsuckers, Psysuckers, Psy-dogs, Poltergeists.\n
+		%c[0,192,71,221] -   4 artefacts: %c[ui_gray_3]Burers, Controllers.\n
+		%c[0,192,71,221] -   5 artefacts: %c[ui_gray_3]Chimeras, Pseudogiants.
 	</text>
-  </string>
+</string>
   <string id="st_pba_af_fonar_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]KLEPTOMANIA\n
-    %c[0,81,63,22] • %c[0,209,172,56]Stashes and items give off a dim light\n
-    %c[0,81,63,22] • %c[0,209,172,56]Stashes emit signal to RF-Receiver\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Stashes and items give off a dim light\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Stashes emit signal to RF-Receiver\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_tapeworm_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]STUNNER\n
-    %c[0,81,63,22] • %c[0,209,172,56]Chance to stun mutant if within 2 meters\n
-    %c[0,81,63,22] • %c[0,209,172,56]Getting hit by a melee attack will stun the attacker for 3 seconds\n
-    %c[0,81,63,22] • %c[0,209,172,56]While stunned, the enemy is unable to attack\n
-    %c[0,81,63,22] • %c[0,209,172,56]Self harm (i.e. fall damage) will result in artefact discharge\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Chance to stun mutant if within 2 meters\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Getting hit by a melee attack will stun the attacker for 3 seconds\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]While stunned, the enemy is unable to attack\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Self harm (i.e. fall damage) will result in artefact discharge\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_moh_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]CULINARY HYPERVERSITY\n
-    %c[0,81,63,22] • %c[0,209,172,56]Convert energy of raw mutant meat into special abilities\n
-    %c[0,81,63,22] • %c[0,209,172,56]Lasts for 1 minute. Eating different mutant meat will override current effect and restart buff timer\n\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Convert energy of raw mutant meat into special abilities\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Lasts for 1 minute. Eating different mutant meat will override current effect and restart buff timer\n\n
     %c[d_orange]Table of effects:\n
 	%c[0,192,71,221] - Flesh meat: %c[ui_gray_3]1%/sec health regen, 33% bullet damage penalty\n
 	%c[0,192,71,221] - Boar meat: %c[ui_gray_3]25% melee damage reduction\n
@@ -260,44 +267,44 @@
 	%c[0,192,71,221] - Chimera: %c[ui_gray_3]2%/sec health regen, 10%/sec stamina regen, 33% radiation damage reduction\n
 	%c[0,192,71,221] - Lurker: %c[ui_gray_3]33% chem/fire/electric anomaly damage reduction\n
 	%c[0,192,71,221] - Tushkano: %c[ui_gray_3]20% speed increase, 20% melee damage penalty\n
-	%c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+	%c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_serofim_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]RAIN OF REVIVAL\n
-    %c[0,81,63,22] • %c[0,209,172,56]Upon receiving a fatal blow, the artefact is destroyed and the player is revived\n
-    %c[0,81,63,22] • %c[0,209,172,56]50% of health is restored, all debuffs are removed and 5 seconds of damage immunity are granted upon revival\n
-    %c[0,81,63,22] • %c[0,209,172,56]Upon revival, the current weapon is dropped and vision is negatively effected\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Upon receiving a fatal blow, the artefact is destroyed and the player is revived\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]50% of health is restored, all debuffs are removed and 5 seconds of damage immunity are granted upon revival\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Upon revival, the current weapon is dropped and vision is negatively effected\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_elektron_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]HIGH VOLTAGE\n
-    %c[0,81,63,22] • %c[0,209,172,56]Stepping on an Electra anomaly will recharge batteries and active devices\n
-    %c[0,81,63,22] • %c[0,209,172,56]Stepping on an Electra anomaly allows infinite sprint for a short period of time\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Stepping on an Electra anomaly will recharge batteries and active devices\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Stepping on an Electra anomaly allows infinite sprint for a short period of time\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_red]NO
 	</text>
   </string>
   <string id="st_pba_af_kogot_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]BLOODLUST\n
-    %c[0,81,63,22] • %c[0,209,172,56]Passive +10% melee damage\n
-    %c[0,81,63,22] • %c[0,209,172,56]3.5% of melee damage is converted to health\n
-    %c[0,81,63,22] • %c[0,209,172,56]Upon killing certain mutants, there is a chance that raw meat will spawn in the vicinity\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Passive +10% melee damage\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]3.5% of melee damage is converted to health\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Upon killing certain mutants, there is a chance that raw meat will spawn in the vicinity\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
   <string id="st_pba_af_dragon_eye_perk">
     <text>
     %c[0,209,172,56]Perk: %c[d_orange]ULTRA-VIOLENCE\n
-    %c[0,81,63,22] • %c[0,209,172,56]5% chance that shots will be explosive\n
-    %c[0,81,63,22] • %c[0,209,172,56]There is a chance that an npc or mutant killed with an explosive shot will also violently explode\n
-    %c[0,81,63,22] • %c[0,209,172,56]Effect stacks with multiple artefacts (chance of an explosion)\n
-    %c[0,81,63,22] • %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
-    %c[0,81,63,22] • %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]5% chance that shots will be explosive\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]There is a chance that an npc or mutant killed with an explosive shot will also violently explode\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Effect stacks with multiple artefacts (chance of an explosion)\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Multiple Artefacts Stack?: %c[ui_green]YES\n
+    %c[0,81,63,22] â€¢ %c[0,209,172,56]Diminishing Returns?: %c[ui_green]NO
 	</text>
   </string>
 </string_table>

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/demonized_geometry_ray.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/demonized_geometry_ray.script
@@ -1,0 +1,386 @@
+local enable_debug = false
+local print_tip = function(s, ...)
+    local f = print_tip or printf
+    if enable_debug then
+        return f("Geometry Ray: " .. s, ...)
+    end
+end
+
+local function throttle(func, tg_throttle)
+    local tg = 0
+    if not tg_throttle or tg_throttle == 0 then
+        return function(...)
+            local t = time_global()
+            if t ~= tg then
+                tg = t
+                return func(...)
+            end
+        end
+    else
+        return function(...)
+            local t = time_global()
+            if t < tg then return end
+            tg = t + tg_throttle
+            return func(...)
+        end
+    end
+end
+
+-- Check for material (engine edit required)
+function lshift(x, by)
+    return x * 2 ^ by
+end
+
+function test(x, mask)
+    return bit_and(x, mask) == mask
+end
+
+local flags_test = {
+    ["flBreakable"] = lshift(1, 0),
+    ["flBounceable"] = lshift(1, 2),
+    ["flSkidmark"] = lshift(1, 3),
+    ["flBloodmark"] = lshift(1, 4),
+    ["flClimable"] = lshift(1, 5),
+    ["flPassable"] = lshift(1, 7),
+    ["flDynamic"] = lshift(1, 8),
+    ["flLiquid"] = lshift(1, 9),
+    ["flSuppressShadows"] = lshift(1, 10),
+    ["flSuppressWallmarks"] = lshift(1, 11),
+    ["flActorObstacle"] = lshift(1, 12),
+    ["flNoRicoshet"] = lshift(1, 13),
+    ["flInjurious"] = lshift(1, 28),
+    ["flShootable"] = lshift(1, 29),
+    ["flTransparent"] = lshift(1, 30),
+    ["flSlowDown"] = lshift(1, 31),
+}
+
+--[[
+
+// material exports
+.def_readonly( "material_name"                    , &script_rq_result::pMaterialName )
+.def_readonly( "material_flags"                   , &script_rq_result::pMaterialFlags )
+.def_readonly( "material_phfriction"              , &script_rq_result::fPHFriction )
+.def_readonly( "material_phdamping"               , &script_rq_result::fPHDamping )
+.def_readonly( "material_phspring"                , &script_rq_result::fPHSpring )
+.def_readonly( "material_phbounce_start_velocity" , &script_rq_result::fPHBounceStartVelocity )
+.def_readonly( "material_phbouncing"              , &script_rq_result::fPHBouncing )
+.def_readonly( "material_flotation_factor"        , &script_rq_result::fFlotationFactor )
+.def_readonly( "material_shoot_factor"            , &script_rq_result::fShootFactor )
+.def_readonly( "material_shoot_factor_mp"         , &script_rq_result::fShootFactorMP )
+.def_readonly( "material_bounce_damage_factor"    , &script_rq_result::fBounceDamageFactor )
+.def_readonly( "material_injurious_speed"         , &script_rq_result::fInjuriousSpeed )
+.def_readonly( "material_vis_transparency_factor" , &script_rq_result::fVisTransparencyFactor )
+.def_readonly( "material_snd_occlusion_factor"    , &script_rq_result::fSndOcclusionFactor )
+.def_readonly( "material_density_factor"          , &script_rq_result::fDensityFactor )
+
+]]
+
+-- Geometry Ray class by Thial, edited by demonized
+class "geometry_ray"
+
+--[[
+(At least one range parameter should be specified)
+ray_range:
+    Defines the total range of the ray. If you want to attach the ray to
+    a fast moving object it is good to extend the ray so that you can reduce
+    the polling rate by using the get function.
+contact_range:
+    Defines the distance at which the result will report being in contact.
+    You can skip it or set it to a value lower than the ray_range to
+    still be able to get the intersection position from the result while
+    marking the ray as not being in contact yet
+distance_offset:
+    Defines how much the intersection position is offset.
+    You can use both positive and negative values or you can leave it blank.
+flags (bit map = values can be added together for combined effect):
+    0 : None
+    1 : Objects
+    2 : Statics
+    4 : Shapes
+    8 : Obstacles
+]]--
+function geometry_ray:__init(args)
+    local args = args or {}
+    if args.ray_range == nil and args.contact_range == nil then
+        return nil
+    end
+
+    self.ray_range = args.ray_range or args.contact_range
+    self.contact_range = args.contact_range or args.ray_range
+    self.distance_offset = args.distance_offset ~= nil and args.distance_offset or 0
+    self.ray = ray_pick()
+    self.ray:set_flags(args.flags or 2)
+    self.ray:set_range(self.ray_range)
+    self.visualize = args.visualize
+    self.visualize_end_pos_only = args.visualize_end_pos_only
+    if args.ignore_object then
+        self.ray:set_ignore_object(args.ignore_object)
+    end
+end
+
+--[[
+position:
+    position from which the ray will start
+direction:
+    direction in which the ray will be fired
+]]--
+function geometry_ray:get(position, direction)    
+    if position == nil or direction == nil then
+        return nil
+    end
+
+    local position = vector():set(position)
+    local direction = vector():set(direction)
+
+    self.ray:set_position(position)
+    self.ray:set_direction(direction)
+    local res = self.ray:query()
+    local distance = res and self.ray:get_distance() or self.ray_range
+    local result = {}
+    if self.visualize then
+        local init_pos = vector():set(position)
+        local end_pos = vector():mad(init_pos, direction, distance)
+        VisualizeRay(init_pos, end_pos, nil, nil, nil, self.visualize_end_pos_only)
+    end
+    result.in_contact = distance <= self.contact_range
+    result.position = position:add(direction:mul(distance + self.distance_offset))
+    result.distance = distance
+    result.raw_distance = self.ray:get_distance()
+    result.success = res
+    result.object = self.ray:get_object()
+    result.element = self.ray:get_element()
+    result.result = self.ray:get_result()
+
+    -- Cast to Lua table
+    -- if result.result then
+    --     local r = {}
+    --     r.material_name = result.result.material_name
+    --     r.material_flags = result.result.material_flags
+    --     r.material_phfriction = result.result.material_phfriction
+    --     r.material_phdamping = result.result.material_phdamping
+    --     r.material_phspring = result.result.material_phspring
+    --     r.material_phbounce_start_velocity = result.result.material_phbounce_start_velocity
+    --     r.material_phbouncing = result.result.material_phbouncing
+    --     r.material_flotation_factor = result.result.material_flotation_factor
+    --     r.material_shoot_factor = result.result.material_shoot_factor
+    --     r.material_shoot_factor_mp = result.result.material_shoot_factor_mp
+    --     r.material_bounce_damage_factor = result.result.material_bounce_damage_factor
+    --     r.material_injurious_speed = result.result.material_injurious_speed
+    --     r.material_vis_transparency_factor = result.result.material_vis_transparency_factor
+    --     r.material_snd_occlusion_factor = result.result.material_snd_occlusion_factor
+    --     r.material_density_factor = result.result.material_density_factor
+
+    --     result.result = r
+    -- end
+
+    return result
+end
+
+-- Engine edit required for testing materials
+-- If not possible to get material - return nil
+function geometry_ray:isMaterialFlag(flag)
+    local result = self.ray:get_result()
+    if not result then
+        return
+    end
+
+    if not result.material_flags then
+        return
+    end
+
+    if not flags_test[flag] then
+        return
+    end
+
+    return test(result.material_flags, flags_test[flag])
+end
+
+function geometry_ray:getMaterialFlags()
+    local result = self.ray:get_result()
+    if not result then
+        return
+    end
+
+    if not result.material_flags then
+        return
+    end
+
+    local res = {}
+    for k, v in pairs(flags_test) do
+        res[k] = test(result.material_flags, v)
+    end
+
+    return res
+end
+
+-- Utils
+-- Check if values are similar to a precision
+function similar(float1, float2, epsilon)
+    return math.abs(float1 - float2) <= (epsilon or 0.0001)
+end
+
+function vec_similar(vec1, vec2, epsilon)
+    return similar(vec1.x, vec2.x, epsilon) and similar(vec1.y, vec2.y, epsilon) and similar(vec1.z, vec2.z, epsilon)
+end
+
+-- Linear inter/extrapolation
+function lerp(a, b, f)
+    if a and b and f then
+        return a + f * (b - a)
+    else
+        return a or b or 0
+    end
+end
+
+-- Visualize ray from one point to other with particles playing at setted step
+class "VisualizeRay"
+local lineId = 70000
+function VisualizeRay:__init(init_pos, end_pos, particle_step, visualize_time, force_stop, draw_end_only, color)
+    self.init_pos = init_pos
+    self.end_pos = end_pos
+    self.visualize_time = visualize_time or 3000
+    self.particle_step = particle_step or 0.02
+    self.force_stop = force_stop
+    self.force_stop_default = force_stop
+    self.time = 0
+    self.draw_end_only = draw_end_only
+    self.color = color or fcolor():set(0,1,0,1)
+
+    self.start = function()
+        lineId = lineId + 1
+        local id = lineId
+        local line = debug_render.add_object(id, DBG_ScriptObject.line):cast_dbg_line()
+        line.point_a = init_pos
+        line.point_b = end_pos
+        line.visible = true
+        line.color = self.color
+        CreateTimeEvent("geometry_ray_stop", id, self.visualize_time / 1000, function()
+            debug_render.remove_object(id)
+            lineId = lineId - 1
+            return true
+        end)
+    end
+    self.start()
+
+    self.reset_time = function()
+        self.time = 0
+    end
+
+    self.reset = function()
+        self.time = 0
+        self.force_stop = self.force_stop_default
+        self.start()
+    end
+
+    self.stop = function()
+        self.time = self.visualize_time + 1
+        self.force_stop = true
+    end
+end
+
+local EPS = 0.0000100
+local function fsimilar(value, to, eps)
+    return math.abs(value - to) < eps
+end
+
+local function generate_orthonormal_basis_normalized(d)
+    local dir = vector():set(d):normalize()
+    local up = vector():set(0,0,0)
+    local right = vector():set(0,0,0)
+    local fInvLength
+    if (fsimilar(dir.y, 1.0, EPS)) then
+        up:set(0, 0, 1)
+        fInvLength = 1 / math.sqrt(dir.x * dir.x + dir.y * dir.y)
+        right.x = -dir.y * fInvLength
+        right.y = dir.x * fInvLength
+        right.z = 0
+        up.x = -dir.z * right.y
+        up.y = dir.z * right.x
+        up.z = dir.x * right.y - dir.y * right.x
+    else
+        up:set(0, 1, 0)
+        fInvLength = 1 / math.sqrt(dir.x * dir.x + dir.z * dir.z)
+        right.x = dir.z * fInvLength
+        right.y = 0
+        right.z = -dir.x * fInvLength
+        up.x = dir.y * right.z
+        up.y = dir.z * right.x - dir.x * right.z
+        up.z = -dir.y * right.x
+    end
+    return dir, up, right
+end
+
+-- Get surface normals by Aoldri, edited by demonized
+function get_surface_normal(pos, dir, ray_props, visualize_props, initial_ray)
+    local function get_geometry_ray()
+        return geometry_ray({
+            ray_range = ray_props and ray_props.ray_range or 1000,
+            visualize = ray_props and ray_props.visualize,
+            flags = ray_props and ray_props.flags or (1+2),
+            ignore_object = db.actor,
+        })
+    end
+
+    -- Get player's camera position and direction in world space
+    local pos0 = pos and vector():set(pos) or device().cam_pos
+    local angle1 = dir and vector():set(dir) or device().cam_dir
+
+    -- Generate two positions orthogonal to camera direction and each other
+    local angle1, pos01, pos02 = generate_orthonormal_basis_normalized(angle1)
+    pos01 = pos01:mul(0.01)
+    pos02 = pos02:mul(0.01)
+
+    pos01 = pos01:add(pos0)
+    pos02 = pos02:add(pos0)
+
+    -- Get positions of intersections of rays around pos0
+    local pos1
+    local res
+    if initial_ray then
+        pos1 = initial_ray.position
+        res = initial_ray
+    else
+        local ray = get_geometry_ray()
+        res = ray:get(pos0, angle1)
+        pos1 = res.position
+    end
+
+    local ray = get_geometry_ray()
+    local pos2 = ray:get(pos01, angle1).position
+
+    local ray = get_geometry_ray()
+    local pos3 = ray:get(pos02, angle1).position
+
+    if not res.success then
+        -- print_tip("cant get normal by pos %s, dir %s", pos0, angle1)
+        return
+    end
+
+    -- VisualizeRay(pos0, pos1, nil, 300)
+    -- VisualizeRay(pos01, pos2, nil, 300)
+    -- VisualizeRay(pos02, pos3, nil, 300)
+
+    -- Get vectors from intersection points from pos1
+    local vec2 = vec_sub(pos1, pos2)
+    local vec3 = vec_sub(pos1, pos3)
+
+    -- Find normal vector of surface by taking cross product of intersection vectors
+    local cross = (vector_cross(vec2, vec3)):normalize()   
+
+    -- If the direction and normal vectors heading in similar direction - invert normal
+    local deg = angle1:dotproduct(cross)
+    if deg > 0 then
+        cross:invert()
+    end
+
+    cross.x = clamp(cross.x, -1, 1)
+    cross.y = clamp(cross.y, -1, 1)
+    cross.z = clamp(cross.z, -1, 1)
+
+    if visualize_props then
+        local time = visualize_props.visualize_time or 300
+        local color = visualize_props.color or fcolor():set(0,1,0,1)
+        VisualizeRay(pos1, vector():set(pos1):add(cross), nil, time, nil, nil, color)
+    end
+    return cross
+end

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
@@ -1412,42 +1412,61 @@ artefact_props = { -- Special props of artefacts that are used in processing
 	af_ball = {
 		monster_tiers = { -- Monster Tiers opening by artefact count
 			[1] = {
+				clsid.zombie,
 				clsid.zombie_s,
+				clsid.cat,
 				clsid.cat_s,
+				clsid.dog_black,
+				clsid.dog_red,
 				clsid.dog_s,
+				clsid.rat,
+				clsid.rat_s,
+				clsid.tushkano,
+				clsid.tushkano_s,
 				"SM_PIRANHA",
 			},
 			[2] = {
+				clsid.boar,
 				clsid.boar_s,
+				clsid.flesh,
 				clsid.flesh_s,
 				clsid.fracture_s,
 				clsid.pseudodog_s,
-				clsid.psy_dog_s,
+				clsid.snork,
+				clsid.snork_s,
+				"SM_LURKER",
 			},
 			[3] = {
+				clsid.bloodsucker,
 				clsid.bloodsucker_s,
-				clsid.snork_s,
 				"SM_KARLIK",
 				"SM_PSYSUCKER",
-				"SM_LURKER",
 				"SM_VOLK",
 				"SM_POLTER_CORP",
 				135, -- Borya
+				clsid.poltergeist,
+				clsid.poltergeist_s,
+				clsid.psy_dog_s,
 			},
 			[4] = {
+				clsid.burer,
 				clsid.burer_s,
+				clsid.controller,
 				clsid.controller_s,
 				"SM_TARK",
 			},
 			[5] = {
+				clsid.chimera,
 				clsid.chimera_s,
 				clsid.gigant_s,
+				clsid.pseudo_gigant,
 				"SM_MEDVED",
 				"SM_MONSTER_BOAR",
 				"SM_VENDIGO",
 				131, -- Bibliotekar
 			}
 		},
+		scan_radius = 2.7,	-- this is the original value from PBA 2.1
 		monsters = {} -- Generated table to check if current monster is allowed to be kick
 	},
 	af_spaika = {
@@ -2792,11 +2811,14 @@ artefact_on_update_functions = {
 			local heal_companion_min_health = 1
 			for id, v in pairs(non_task_companions) do
 				local obj = get_object_by_id(id)
-				local obj_community = obj:character_community()
-				if af_chelust.valid_companion_communities[obj_community] and obj.health < heal_companion_min_health then
-					heal_companion_min_health = obj.health
-					heal_companion = obj
-					trace("found companion %s, community %s, health %s", id, obj_community, heal_companion_min_health)
+				-- ilrathCXV (01/31/25): Valid check to avoid crashes in edge cases
+				if obj then
+					local obj_community = obj:character_community()
+					if af_chelust.valid_companion_communities[obj_community] and obj.health < heal_companion_min_health then
+						heal_companion_min_health = obj.health
+						heal_companion = obj
+						trace("found companion %s, community %s, health %s", id, obj_community, heal_companion_min_health)
+					end
 				end
 			end
 
@@ -3848,7 +3870,7 @@ artefact_on_equip_functions = {
 	af_ball = function(actor, artefact_count, artefact_ids, artefact_names)
 		local af_ball = artefact_props.af_ball
 		empty_table(af_ball.monsters)
-		for i = 1, artefact_count do
+		for i = 1, math.min(artefact_count, 5) do
 			for j, monster in ipairs(af_ball.monster_tiers[i]) do
 				af_ball.monsters[monster] = true
 			end
@@ -3954,6 +3976,196 @@ lucifer_sacrifice_func = {
 }
 add_functor("pba_lucifer", lucifer_sacrifice_func.check_lucifer_condition, lucifer_sacrifice_func.check_sacrifice, nil, lucifer_sacrifice_func.lucifer_sacrifice, true)
 
+-- Functions for artefacts on key press
+artefact_on_key_press_functions = {
+	-- Ball
+	af_ball = function(actor, artefact_count, artefact_ids, artefact_names, key)
+		local af_ball = artefact_props.af_ball
+		if not check_cooldown("af_ball") then return end
+
+		local bind = dik_to_bind(key)
+		if (bind == key_bindings.kUSE) then
+			local distance = math.huge
+			local target
+			local pointed = level.get_target_obj()
+			level.iterate_nearest(actor:position(), af_ball.scan_radius + 1, function(obj)
+				if not 
+				(
+					obj:id() ~= AC_ID
+					and (
+						(IsMonster(obj) and 
+						(
+							af_ball.monsters[obj:clsid()] or af_ball.monsters[SYS_GetParam(
+								2,
+								obj:section(),
+								"kind",
+								"definitely_not_found_kind"
+							)]
+						))
+						-- or (IsStalker(obj) and xr_combat_ignore.fighting_with_actor_npcs[obj:id()])
+					)
+					and obj:alive()
+					and obj:position():distance_to(actor:position()) <= af_ball.scan_radius
+				) then
+					-- printf("target %s is invalid", obj:name())
+					return
+				end
+
+				-- Pointed target takes priority
+				if pointed and pointed:id() == obj:id() then
+					-- printf("target %s is pointed", obj:name())
+					target = obj
+					return true
+				end
+
+				local pos = obj:position()
+
+				-- Visibility check, position or obj bones
+				local visibility_checks = {
+					function()
+						local see = game.world2ui(obj:position())
+						return (see.x > 0 and see.x < 1024 and see.y > 0 and see.y < 1024)
+					end,
+					function()
+						local pos = utils_obj.safe_bone_pos(obj, "bip01_spine")
+						if not (pos and pos.x ~= 0 and pos.y ~= 0 and pos.z ~= 0) then return end
+
+						local see = game.world2ui(pos)
+						return (see.x > 0 and see.x < 1024 and see.y > 0 and see.y < 1024)
+					end,
+					function()
+						local pos = utils_obj.safe_bone_pos(obj, "bip01_head")
+						if not (pos and pos.x ~= 0 and pos.y ~= 0 and pos.z ~= 0) then return end
+
+						local see = game.world2ui(pos)
+						return (see.x > 0 and see.x < 1024 and see.y > 0 and see.y < 1024)
+					end,
+				}
+				local see = false
+				for i, v in ipairs(visibility_checks) do
+					if v() then
+						see = true
+						break
+					end
+				end
+				if not see then
+					-- printf("cant see")
+					return
+				end
+
+				-- Obstacle check, rays
+				local obstacle_checks = {
+					function()
+						local ray = demonized_geometry_ray.geometry_ray({
+							ray_range = 200,
+							ignore_object = obj,
+							flags = 3,
+						})
+						local res = ray:get(pos, actor:position():sub(pos):normalize())
+						return res.result and res.result.object and res.result.object:id() == AC_ID
+					end,
+					function()
+						local p = utils_obj.safe_bone_pos(actor, "bip01_spine")
+						if not (p and p.x ~= 0 and p.y ~= 0 and p.z ~= 0) then return end
+
+						local ray = demonized_geometry_ray.geometry_ray({
+							ray_range = 200,
+							ignore_object = obj,
+							flags = 3,
+						})
+						local res = ray:get(pos, p:sub(pos):normalize())
+						return res.result and res.result.object and res.result.object:id() == AC_ID
+					end,
+				}
+				local no_obstacle = false
+				for i, v in ipairs(obstacle_checks) do
+					if v() then
+						no_obstacle = true
+						break
+					end
+				end
+				if not no_obstacle then
+					-- printf("obstacled")
+					return
+				end
+
+				local dist = pos:distance_to_sqr(actor:position())
+				if dist < distance then
+					distance = dist
+					target = obj
+				end
+			end)
+			if not target then return end
+			
+			-- ilrathCXV (01/31/25): We will be getting mutant's true health value as the hit power to avoid "Strength" leveling too fast
+			local t_health = ini_sys:r_float_ex(target:section(), "Health") or 100
+			t_health = (t_health * 0.01) -- + 1 -- adding a +1 to ensure enemy dies
+			
+			local pos = actor:position()
+			local h = hit()
+			local direction = device().cam_dir
+			local magnitude = artefact_count * 60
+			direction.x = direction.x * 1000 * magnitude
+			direction.y = random_float(0.1, 0.2) * 5000 * magnitude
+			direction.z = direction.z * 1000 * magnitude
+			h.power = t_health	--10000
+			h.direction = direction
+			h.bone = "bip01_spine"
+			h.draftsman = actor
+			h.impulse = 10000	--6000
+			h.type = hit.wound
+			
+			-- ilrathCXV (01/31/25): Will ensure the enemy dies from this hit (some enemies have enough  resistance to outlive a hit even if matching their HP)
+			if target:alive() then
+				target:set_health_ex(0.01)
+			end
+			
+			target:hit(h)
+
+			local obj_id = target:id()
+
+			local function fly(obj_id)
+				local monster = get_object_by_id(obj_id)
+				if monster and not monster:alive() and monster:get_physics_shell() then
+					trace("monster dead, physics shell works")
+					monster:get_physics_shell():apply_force(direction.x, direction.y, direction.z)
+					play_sound_on_actor("perk_based_artefacts\\BIGGIB0" .. random(6), 1, random_float(0.9, 1.0))
+					local position = monster:position()
+					position.y = position.y + 1
+					
+					if artefact_count < 2 then
+						play_sound_on_actor("perk_based_artefacts\\BONSNAP" .. random(8), 0.1 + 0.2 * (artefact_count - 1), random_float(0.9, 1.0))
+						local gibs = particles_object("artefact\\effects\\af_idle_dist")
+						if gibs and not gibs:playing() then
+							gibs:play_at_pos(position)
+						end
+					elseif artefact_count < 4 then
+						play_sound_on_actor("perk_based_artefacts\\BONSNAP" .. random(8), 0.7, random_float(0.9, 1.0))
+						local gibs = particles_object("artefact\\artefact_mincer")
+						if gibs and not gibs:playing() then
+							gibs:play_at_pos(position)
+						end
+					else
+						play_sound_on_actor("perk_based_artefacts\\GNTEAR0" .. random(2), 0.75, random_float(0.9, 1.0))
+						local gibs = particles_object("artefact\\artefact_gravi")
+						if gibs and not gibs:playing() then
+							gibs:play_at_pos(position)
+						end
+					end
+
+					return true
+				end
+				trace("monster not dead yet")
+				return false
+			end
+			CreateTimeEvent("af_bat_fly" .. obj_id, obj_id, 0, fly, obj_id)
+			
+			add_cooldown(IsStalker(target) and 5 or (1 + 1 * artefact_count), "af_ball")
+		end
+	end,
+}
+
+--[[
 -- Patch for Ball for kicking monsters
 local use_kick = bind_monster.generic_object_binder.use_kick
 bind_monster.generic_object_binder.use_kick = function(self, obj, who)
@@ -3968,7 +4180,10 @@ bind_monster.generic_object_binder.use_kick = function(self, obj, who)
 	end
 
 	if not (obj:alive() and check_cooldown("af_ball")) then return end
-
+	
+	local m_health = ini_sys:r_float_ex(obj:section(), "Health") or 100
+	m_health = m_health / 100
+	
 	local actor = db.actor
 	local pos = actor:position()
 	local h = hit()
@@ -3978,10 +4193,10 @@ bind_monster.generic_object_binder.use_kick = function(self, obj, who)
 	direction.x = direction.x * 1000 * magnitude
 	direction.y = random_float(0.1, 0.2) * 5000 * magnitude
 	direction.z = direction.z * 1000 * magnitude
-	h.power = 10000
+	h.power = m_health
 	h.direction = direction
 	h.bone = "bip01_spine"
-	h.draftsman = obj
+	h.draftsman = actor
 	h.impulse = 10000	--6000
 	h.type = hit.wound
 	obj:hit(h)
@@ -4046,7 +4261,7 @@ bind_monster.generic_object_binder.update = function(self, delta)
 		self.object:set_tip_text(self.object:set_tip_text(game.translate_string("st_body_kick")))
 	end
 end
-
+]]
 -- Patch for First Person Death
 if ayykyu_fp_death and ayykyu_fp_death.actor_on_before_death then
 	local fp_death = ayykyu_fp_death.actor_on_before_death
@@ -4467,6 +4682,10 @@ function monster_on_death_callback(monster, who)
 	process_artefacts(artefact_on_monster_death_functions, monster, who, last_monster_hit, last_monster_hit_bone_index)
 end
 
+function on_key_press(key)
+	process_artefacts(artefact_on_key_press_functions, key)
+end
+
 function on_item_drag_dropped(obj_1, obj_2, slot_from, slot_to)
 	if not (obj_1 and obj_2) then 
 		trace("No obj_1 or obj_2 found, o1 %s, o2 %s", obj_1 and obj_1:section(), obj_2 and obj_2:section())
@@ -4520,6 +4739,9 @@ function actor_on_first_update()
 	RegisterScriptCallback("monster_on_before_hit", monster_on_before_hit)
 	RegisterScriptCallback("monster_on_hit_callback", monster_on_hit_callback)
 	RegisterScriptCallback("monster_on_death_callback", monster_on_death_callback)
+	
+	-- Adding the PBA 2.1 functionality
+	RegisterScriptCallback("on_key_press", on_key_press)
 end
 
 function on_trade_started_set_values()

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
@@ -3995,7 +3995,8 @@ artefact_on_key_press_functions = {
 					and (
 						(IsMonster(obj) and 
 						(
-							af_ball.monsters[obj:clsid()] or af_ball.monsters[SYS_GetParam(
+							-- ilrathCXV (02/01/2025): Fixed Gigant Jumper being classified as a Snork - will now be counted as a Pseduogiant
+							af_ball.monsters[((obj:section() == "gigant_jumper" and clsid.pseudo_gigant) or obj:clsid())] or af_ball.monsters[SYS_GetParam(
 								2,
 								obj:section(),
 								"kind",

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/perk_based_artefacts.script
@@ -3298,7 +3298,7 @@ artefact_on_before_hit_functions = {
 		end
 
 		af_black_angel.dice_roll = random(100)
-		if af_black_angel.dice_roll <= af_black_angel.reflect_chance[artefact_count] then
+		if af_black_angel.dice_roll <= af_black_angel.reflect_chance[math.min(artefact_count, 5)] then
 			s_hit.power = 0.001
 		end
 	end,
@@ -3312,8 +3312,8 @@ artefact_on_before_hit_functions = {
 		end
 
 		local dice_roll = random(100)
-		if dice_roll > af_medallion.reflect_chance[artefact_count] then
-			trace("Medallion, perk not triggered, dice_roll %s, chance %s", dice_roll, af_medallion.reflect_chance[artefact_count])
+		if dice_roll > af_medallion.reflect_chance[math.min(artefact_count, 5)] then
+			trace("Medallion, perk not triggered, dice_roll %s, chance %s", dice_roll, af_medallion.reflect_chance[math.min(artefact_count, 5)])
 			return
 		end
 
@@ -3436,7 +3436,7 @@ artefact_on_before_hit_functions = {
 			return
 		end
 
-		local rad_k = af_cell.reduction_coeff[artefact_count]
+		local rad_k = af_cell.reduction_coeff[math.min(artefact_count, 5)]
 		local power = s_hit.power
 		s_hit.power = s_hit.power * (1 - rad_k)
 		power = power - s_hit.power
@@ -3490,7 +3490,7 @@ artefact_on_before_hit_functions = {
 			return
 		end
 		
-		local fire_damage = af_sun.fire_damage[artefact_count]
+		local fire_damage = af_sun.fire_damage[math.min(artefact_count, 5)]
 		local fire_hit = hit(s_hit)
 		fire_hit.type = hit.burn
 		fire_hit.power = fire_hit.power * fire_damage
@@ -3516,8 +3516,8 @@ artefact_on_hit_functions = {
 	-- Black Angel, perk: Dodge This
 	af_black_angel = function(actor, artefact_count, artefact_ids, artefact_names, obj, amount, who, last_hit)
 		local af_black_angel = artefact_props.af_black_angel
-		if af_black_angel.dice_roll > af_black_angel.reflect_chance[artefact_count] then
-			trace("Black Angel not triggered, dice roll %s, chance %s", af_black_angel.dice_roll, af_black_angel.reflect_chance[artefact_count])
+		if af_black_angel.dice_roll > af_black_angel.reflect_chance[math.min(artefact_count, 5)] then
+			trace("Black Angel not triggered, dice roll %s, chance %s", af_black_angel.dice_roll, af_black_angel.reflect_chance[math.min(artefact_count, 5)])
 			return
 		end
 		if not (


### PR DESCRIPTION
These changes are to provide a better experience with GAMMA's current version of PBA. Here are the changes included with this branch:

- "Ball" perkifact now has its PBA 2.1 functionality (credit to MrDemonized obviously) to fix its current usage issues (i.e. some mutants cannot be "used" due to their "use" point being either extremely small or near-impossible to reach in normal gameplay)
- "Ball" perkifact's mutant tier lists have been fixed for the 2.1 implementation + edited to reflect better balancing of mutant types
- "Ball" perk text will now display the mutant tiers for better understanding for players - **ONLY INCLUDES ENGLISH TRANSLATION**
- Includes `demonized_geometry_ray.script` to avoid any possible crashes due to using 2.1's implementation
- Possible crash fix for "Chain" perkifact due to no validity check when attempting to heal companions

For reference, the new mutant list for the "Ball" is:
- 1 artefact: Cats, Dogs, Tushkanos, Rats, Zombies, Crows
- 2 artefacts: Boars, Flesh, Pseudodogs, Snorks, Lurkers, Fractures
- 3 artefacts: Karliks, Bloodsuckers, Psysuckers, Psy-dogs, Poltergeists
- 4 artefacts: Burers, Controllers
- 5 artefacts: Chimeras, Pseudogiants