### PR TITLE
Same faction armor should not be exchangable

### DIFF
--- a/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/scripts/grok_armor_convert.script
+++ b/G.A.M.M.A/modpack_addons/Grok's and Darkasleif's Armor Exchange/gamedata/scripts/grok_armor_convert.script
@@ -176,7 +176,6 @@ loner_medium = {
 	["isg_lcs_urban_outfit"] = true,
 	["renegademerc_outfit"] = true,
 	["ghillie_outfit"] = true,
-	["travel_outfit"] = true,
 	["dolg_outfit"] = true,
 	["dolg_red_outfit"] = true,
 	["dolg_scout_outfit"] = true,
@@ -197,7 +196,6 @@ loner_medium = {
 	["trenchcoat_green_outfit"] = true,
 	["trenchcoat_dolg_brown_outfit"] = true,
 	["trenchcoat_freedom_brown_outfit"] = true,
-	["nbc_outfit"] = true,
 	["bandit_nbc_outfit"] = true,
 	["cs_nbc_outfit"] = true,
 	["monolith_nbc_outfit"] = true,
@@ -378,7 +376,6 @@ cs_exolight = {
 	["svoboda_exolight_outfit"] = true,
 	["exolight_outfit"] = true,
 	["bandit_exolight_outfit"] = true,
-	["cs_exolight_outfit"] = true,
 }
 
 
@@ -453,7 +450,6 @@ merc_medium = {
 	["monolith_nbc_outfit"] = true,
 	["nbc_dolg_outfit"] = true,
 	["nbc_freedom_outfit"] = true,
-	["nbc_merc_outfit"] = true,
 }
 
 merc_sci = {
@@ -692,7 +688,6 @@ freedom_medium = {
 	["trenchcoat_brown_outfit"] = true,
 	["trenchcoat_green_outfit"] = true,
 	["trenchcoat_dolg_brown_outfit"] = true,
-	["trenchcoat_freedom_brown_outfit"] = true,
 	["nbc_outfit"] = true,
 	["bandit_nbc_outfit"] = true,
 	["cs_nbc_outfit"] = true,
@@ -736,7 +731,6 @@ freedom_skat = {
 freedom_exolight = {
 	["cost"] = 30000, 
 	["reward"] = "svoboda_exolight_outfit",      
-	["freedom_exo_vineleaf_outfit"] = true,
 	["exo_dolg_wood_outfit"] = true,
 	["exo_merc_wood_outfit"] = true,
 	["exo_wood_outfit"] = true,
@@ -1263,7 +1257,6 @@ greh_medium = {
 	["dolg_outfit"] = true,
 	["dolg_red_outfit"] = true,
 	["dolg_scout_outfit"] = true,
-	["greh_ps5_outfit"] = true,
 	["bandit_ps5_outfit"] = true,
 	["svoboda_heavy_outfit_2"] = true,
 	["bandit_sun_outfit"] = true,


### PR DESCRIPTION
I made a [script](https://github.com/SaloEater/Stalker-Gamma-Auto-Sheet/commit/530438b6e5e5196823bc1b0d11f12a7e0072e6e9) to auto-update armor exchange [table](https://docs.google.com/spreadsheets/d/1OWE25Go9kSao5-IDOS4ZWkBtLfyEF_hPLJz7QQR2lqY/edit?gid=1796045690#gid=1796045690) and found out there are some mistakes where you can exchange armor of the same faction.

This PR fixes these.