### PR TITLE
Barrier defense no more spawning upon finished

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/configs/mod_system_barrier_defense_no_more_spawning.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/configs/mod_system_barrier_defense_no_more_spawning.ltx
@@ -1,0 +1,2 @@
+![barrier_defense_squad]
+on_death = {-barrier_defense_zombie_finished +barrier_defense_zombie_first_spawn} nil %=on_barrier_defense_squad_death(barrier_defense_freedom)%, {-barrier_defense_monolith_finished +barrier_defense_monolith_first_spawn} nil %=on_barrier_defense_squad_death(barrier_defense_freedom)%


### PR DESCRIPTION
`+331- Barrier Defense Task Emission Fix - Catspaw` enables the surges during barrier defense quest but squads [keep respawning](https://github.com/Tosox/STALKER-Anomaly-gamedata/blob/32a985509b2d6abc652d1571fe50de5a84c52dd4/gamedata/configs/misc/squad_descr/squad_descr_defense.ltx#L166)
This patch fixes quest and doesn't allow squad to respawn itself

Without patch it's possible to 1) kill all monolith/zombie at barrier 2) wait for emission 3) loot juicy 100500 freedomers that are keep spawning during surge and dying instantly lol
![2](https://github.com/user-attachments/assets/b89a5c2a-a51d-4bee-9c94-2a5950fb31bc)