### PR TITLE
Fix Reefer rewards to not give out non-existent "af_blood_af" and giv…

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/dialogs_agr_u.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/dialogs_agr_u.script
@@ -130,8 +130,8 @@ function give_agr_u_bandit_boss_task_1(a,b)
 	local tsk = tm.task_info["agr_u_bandit_boss_task_1"]
 	if npc and (not tsk) then
 		tm:give_task("agr_u_bandit_boss_task_1", npc and npc:id())
-		if (not npc:object("af_blood_af")) then
-			alife_create_item("af_blood_af", npc) -- spawn on Reefer once you accept the quest
+		if (not npc:object("af_blood")) then
+			alife_create_item("af_blood", npc) -- spawn on Reefer once you accept the quest
 		end
 	end
 end
@@ -172,7 +172,7 @@ end
 -- Rewards
 function give_af_blood_af_iam(a,b)
 	local npc = dialogs.who_is_npc(a, b)
-	itms_manager.relocate_item_to_actor(db.actor, npc, "af_blood_af", 1)
+	itms_manager.relocate_item_to_actor(db.actor, npc, "af_blood", 1)
 end
 function give_money_reward(a,b)
 	xr_effects.reward_random_money(a,b,{"8000","10000"})


### PR DESCRIPTION
…e out proper Stone Blood "af_blood"

So Grok doesn't forget :)
I don't know if I did it right or if function name "af_blood_af_aim" should've been changed too