### PR TITLE
Fix loadscreen freezes by forcing texture_lod 0

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/force_texture_lod.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/force_texture_lod.script
@@ -1,0 +1,3 @@
+exec_console_cmd("texture_lod 0")
+-- texture_lod 2 or higher cause permanent freezes on some levels' loadscreens and issues with sights' reticles render
+-- oleh5230, 31.03.2025

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. UI/gamedata/scripts/ui_options.script
@@ -116,7 +116,7 @@ options = {
 		
 		{ id= "line"				   ,type= "line"	  },
 		{ id= "title"				   ,type= "title"	 ,text= "ui_mm_header_rendering_quality" 		,align= "l"	,clr= {255,200,200,200}	},
-		{ id= "texture_lod"            ,type= "track"    ,val= 2	,cmd= "texture_lod"	                ,min= 0     ,max= 4     ,step= 1 	,no_str= true	  ,invert= true     ,vid= true	,restart= true	},
+		--{ id= "texture_lod"            ,type= "track"    ,val= 2	,cmd= "texture_lod"	                ,min= 0     ,max= 4     ,step= 1 	,no_str= true	  ,invert= true     ,vid= true	,restart= true	},
 		{ id= "geometry_lod"           ,type= "track"    ,val= 2	,cmd= "r__geometry_lod"	            ,min= 0.1   ,max= 1.5   ,step= 0.1 },
 		{ id= "mipbias"           	   ,type= "track"    ,val= 2	,cmd= "r__tf_mipbias"	            ,min= -0.5  ,max= 0.5   ,step= 0.1 	,no_str= true 	  ,invert= true },
 		{ id= "tf_aniso"               ,type= "track"    ,val= 2	,cmd= "r__tf_aniso"	                ,min= 1     ,max= 16    ,step= 4    ,vid= true	},


### PR DESCRIPTION
According to oflin and kostyumier, lowering texture detail parameter is the cause of permanent freezes on level loadscreens.
