### PR TITLE
Remove falling over animation after disabling MM

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Miracle Machine Remake/gamedata/configs/scripts/labx16/brain_system_message.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Miracle Machine Remake/gamedata/configs/scripts/labx16/brain_system_message.ltx
@@ -1,0 +1,45 @@
+[logic]
+active = sr_idle@check_story
+
+[sr_idle@check_story]
+on_info = {+story_mode_disabled} sr_idle@nil, sr_idle@system_idle
+
+[sr_idle@system_idle]
+on_info = {+yan_labx16_switcher_1_off -yan_labx16_switcher_1_end} sr_idle@switcher_1, {+yan_labx16_switcher_primary_off} sr_idle@primary_off %=yan_gluk%
+on_info2 = {+yan_labx16_switcher_2_off -yan_labx16_switcher_2_end} sr_idle@switcher_2
+on_info3 = {+yan_labx16_switcher_3_off -yan_labx16_switcher_3_end} sr_idle@switcher_3 , {+yan_labx16_switcher_primary_try} sr_idle@switcher_primary
+on_info4 = {-yan_labx16_switcher_primary_off} %=play_sound_looped(x16_brain_run)%
+
+[sr_idle@switcher_1]
+on_info = %=stop_sound_looped%
+on_timer = 500 | sr_idle@system_idle %+yan_labx16_switcher_1_end =play_sound_looped(message_3) =play_sound_looped(klaxon_3) =play_sound_looped(rumble_3)%
+
+[sr_idle@switcher_2]
+on_info = %=stop_sound_looped%
+on_timer = 500 | sr_idle@system_idle %+yan_labx16_switcher_2_end =play_sound_looped(message_2) =play_sound_looped(klaxon_2) =play_sound_looped(rumble_2)%
+
+[sr_idle@switcher_3]
+on_info = %=play_sound(x16_begin)%
+on_timer = 9000 | sr_idle@system_idle %+yan_labx16_switcher_3_end =play_sound_looped(message_1) =play_sound_looped(klaxon_1) =play_sound_looped(rumble_1)%
+
+[sr_idle@switcher_primary]
+on_timer = 500 | sr_idle@system_idle %-yan_labx16_switcher_primary_try%
+
+[sr_idle@primary_off]
+on_info = %=stop_sound_looped =play_sound(x16_brain_stop)%
+on_timer = 1000 | sr_idle@primary_idle ;%=run_cam_effector(radar_stop:2506:false)%
+
+[sr_idle@primary_idle]
+on_timer = 100 | sr_idle@primary_idle_2
+
+[sr_idle@primary_idle_2]
+on_timer = 100 | sr_idle@primary_idle_3
+
+[sr_idle@primary_idle_3]
+on_info  = {+yantar_find_ghost_task_start} sr_idle@primary_idle_4
+on_timer = 17000 | %=play_sound_looped(x16_brain_death_d)%
+
+[sr_idle@primary_idle_4]
+on_timer = 100 | sr_idle@nil
+
+[sr_idle@nil]


### PR DESCRIPTION
Removes the funny falling over camera effector in X-16 (leftover from the original game cutscene)