### PR TITLE
Remove F1 grenade despawn

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Skill System Balance/gamedata/scripts/haru_skills.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Skill System Balance/gamedata/scripts/haru_skills.script
@@ -359,7 +359,7 @@ function scavanger_effect(npc)
 				--alife_release(item)
 			end
 
-		if item:section() == "grenade_f1" or item:section() == "detector_elite" or item:section() == "detector_scientific" then
+		if item:section() == "detector_elite" or item:section() == "detector_scientific" then
 			alife_release(item)
 		end
 		


### PR DESCRIPTION
Since loadouts have been reworked F1 grenades are not as common, despawning seems redundant.