### PR TITLE
Tasks QoL Pack | Re-adds feature lost during back button integration

### DIFF
--- a/G.A.M.M.A/modpack_addons/Serious Tasks QoL Pack/gamedata/scripts/ui_pda_taskboard_tab.script
+++ b/G.A.M.M.A/modpack_addons/Serious Tasks QoL Pack/gamedata/scripts/ui_pda_taskboard_tab.script
@@ -424,9 +424,8 @@ function update_task_entry(pda_tab, i, task_details)
 	end
 	
 	row.task_next_btn:Show(has_more_task_in_category(i))
-	manage_accept_button(stalker, row, more_task_details.faulty)
 	pda_tab.rows[i].task_previous_btn:Show(has_previous_task_in_category(i))
-	manage_accept_button(stalker, row)
+	manage_accept_button(stalker, row, more_task_details.faulty)
 end
 
 --Flavor stuff for buggy tasks


### PR DESCRIPTION
The hiding of the accept button when encountering a buggy task feature was accidentally deleted during the integration of the PDA Back Button. This PR re-adds it.