### PR TITLE
Fixes Black Market crash

### DIFF
--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -61,6 +61,7 @@
 +G.A.M.M.A. No Copyrighted Music
 -343- G.A.M.M.A. Traduccion Espanola - vdltman
 -340- Black Market (Buyable Gear) - SalamanderAnder & nox
++Momopate's Barrel Condition Effects Display
 -Demonized Death Animations
 +Serious Tasks QoL Pack
 -Pre-0.9.3.1 Saves Fix
@@ -144,7 +145,6 @@
 +Particles Cinematic VFX 3.5 1.1.2 BOTZ YAWM
 +Maid's and Grok's BaS Dynamic Zoom Enabler
 +Momopate's Detailed Weapon Stats
-+Momopate's Barrel Condition Effects Display
 -Momopate's Loot Stabilizer
 +LVutner's Shader Corner Shadow Fix
 -Optional Modern UI font


### PR DESCRIPTION
Momo's mod was already highest priority from the active modlist, so we can safely move it to wherever we want to.