### PR TITLE
Fix Black Market exploit and ZCP crash

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Vices are free/gamedata/scripts/bind_awr.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Vices are free/gamedata/scripts/bind_awr.script
@@ -25,7 +25,7 @@ function access(obj) --| Access to a vice, taking into account possible death of
 	end
 	
 	--// You should be able to use any workshop in Warfare mode 
-	if _G.WARFARE or (smr_amain_mcm.get_config("smr_enabled") and smr_stalkers_mcm.get_config("base_population") == "sim_smr_none") then
+	if _G.WARFARE or (smr_amain_mcm and smr_amain_mcm.get_config("smr_enabled") and smr_stalkers_mcm and smr_stalkers_mcm.get_config("base_population") == "sim_smr_none") then
 		return true
 	end
 	

--- a/G.A.M.M.A/modpack_addons/Momopate's Barrel Condition Effects Display/gamedata/scripts/zzzz_arti_jamming_repairs.script
+++ b/G.A.M.M.A/modpack_addons/Momopate's Barrel Condition Effects Display/gamedata/scripts/zzzz_arti_jamming_repairs.script
@@ -769,21 +769,25 @@ function name_fieldstrip(obj, bag, mode)
 end
 
 function has_parts_fieldstrip(wpn, bag, mode)
-	local mode = {
+	local allowedMode = {
 		["inventory"] = true,
 		["loot"] = true,
 	}
-	local bag = {
+	local allowedBag = {
 		["actor_equ"] = true,
 		["actor_belt"] = true,
 		["actor_bag"] = true,
 		["npc_bag"] = true,
 	}
+
+	--SERIOUS: Prevents field stripping in trade windows. (Black Market and some gun mods include weapons on traders)
+	if not allowedBag[bag] or not allowedMode[mode] then return false end
+
 	if not has_parts(wpn) then return false end
-	local parts = item_parts.get_parts_con(wpn, nil, true)
-	local has_parts = false
-	for k,v in spairs(parts, sort_parts) do
-		if v > 0 and is_part(k) and not arti_jamming.is_barrel(k) then has_parts = true end
+		local parts = item_parts.get_parts_con(wpn, nil, true)
+		local has_parts = false
+		for k,v in spairs(parts, sort_parts) do
+			if v > 0 and is_part(k) and not arti_jamming.is_barrel(k) then has_parts = true end
 	end
 	return has_parts
 end


### PR DESCRIPTION
Fixes an exploit that allowed the field strip menu to appear in trade windows.
Fixes a crash where ppl with ZCP turned off crash on trying to use the mechanic's workbench.