### PR TITLE
Fixes Black Market's priority

### DIFF
--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -60,8 +60,8 @@
 +G.A.M.M.A. New Main Menu
 +G.A.M.M.A. No Copyrighted Music
 -343- G.A.M.M.A. Traduccion Espanola - vdltman
--340- Black Market (Buyable Gear) - SalamanderAnder & nox
 +Momopate's Barrel Condition Effects Display
+-340- Black Market (Buyable Gear) - SalamanderAnder & nox
 -Demonized Death Animations
 +Serious Tasks QoL Pack
 -Pre-0.9.3.1 Saves Fix


### PR DESCRIPTION
Black market now gets overwritten by `Momopate's Barrel Condition Effects Display` as it was intended to do so.