### PR TITLE
Mutant Spawn Tweaks

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/marsh/smart/mar_smart_terrain_4_5.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/marsh/smart/mar_smart_terrain_4_5.ltx
@@ -1,0 +1,19 @@
+[smart_terrain];mar_smart_terrain_4_5 ;;затопленный хутор с водонапорной башней
+squad_id = 10
+max_population = 1
+respawn_params = respawn@mar_smart_terrain_4_5
+respawn_idle = 86400
+
+[respawn@mar_smart_terrain_4_5]
+spawn_zombie
+
+[spawn_zombie]
+spawn_squads = zombied_sim_squad_mix, simulation_zombie, simulation_mix_zombie
+spawn_num = 1
+
+[exclusive]
+mar_smart_terrain_4_5_camp_work_1 = marsh\mar_smart_terrain_4_5_smart_logic.ltx
+mar_smart_terrain_4_5_camp_work_2 = marsh\mar_smart_terrain_4_5_smart_logic.ltx
+mar_smart_terrain_4_5_camp_work_3 = marsh\mar_smart_terrain_4_5_smart_logic.ltx
+mar_smart_terrain_4_5_camp_work_4 = marsh\mar_smart_terrain_4_5_smart_logic.ltx
+mar_smart_terrain_4_5_camp_work_5 = marsh\mar_smart_terrain_4_5_smart_logic.ltx

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. ZCP 1.4 Balanced Spawns/gamedata/scripts/smr_pop.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. ZCP 1.4 Balanced Spawns/gamedata/scripts/smr_pop.script
@@ -966,7 +966,7 @@ local function get_total_weight_on_level(level_name)
     local filtered_spawn_table_on_level = {}
     for i, mutant in pairs(mutant_spawn_per_level[level_name]) do
         -- filter disabled mutants in menu
-        if flipped_mutant_spawn_table[mutant] and mutant ~= "m_poltergeist_" and mutant ~= "burer_" then
+        if flipped_mutant_spawn_table[mutant] then
             table_insert(filtered_spawn_table_on_level, mutant)
         end
     end

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. ZCP 1.4 Balanced Spawns/gamedata/scripts/smr_pop.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. ZCP 1.4 Balanced Spawns/gamedata/scripts/smr_pop.script
@@ -966,7 +966,7 @@ local function get_total_weight_on_level(level_name)
     local filtered_spawn_table_on_level = {}
     for i, mutant in pairs(mutant_spawn_per_level[level_name]) do
         -- filter disabled mutants in menu
-        if flipped_mutant_spawn_table[mutant] then
+        if flipped_mutant_spawn_table[mutant] and mutant ~= "m_poltergeist_" and mutant ~= "burer_" then
             table_insert(filtered_spawn_table_on_level, mutant)
         end
     end


### PR DESCRIPTION
Burers/poltergeists are partially/completely harmless if there's no heavy dynamic objects in proximity. Spawning them at random smart terrains is irrational.

Village Ruins rat spawn is an oversight in ZCP blacklist system.