### PR TITLE
Fatal Error fixes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Miracle Machine Remake/gamedata/scripts/release_restr_in_x16.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Miracle Machine Remake/gamedata/scripts/release_restr_in_x16.script
@@ -1,0 +1,26 @@
+local function on_game_load()
+	
+	if has_alife_info("x16_restr_release") then
+		return
+	end
+	
+	for i=1, 65534 do
+		
+		local sobj = alife_object(i)
+		
+		if sobj and sobj:name() == "yan_attack_zombies_space_restrictor" then
+			
+			alife_release(sobj, true)
+			give_info("x16_restr_release")
+			
+			break
+		
+		end
+		
+	end
+	
+end
+
+function on_game_start()
+	RegisterScriptCallback("on_game_load", on_game_load)
+end

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_saiga12s_m1_syn.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_saiga12s_m1_syn.ltx
@@ -1,6 +1,7 @@
 ![wpn_saiga12s_m1]
 		!shell_point
 		!shell_particles
+        shell_bone = bolt
 		
 		snd_draw				= weapons\saiga_eft\draw
 		snd_holster				= weapons\saiga_eft\holster

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_saiga12s_m2_syn.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/mod_system_saiga12s_m2_syn.ltx
@@ -1,6 +1,7 @@
 ![wpn_saiga12s_m2]
 		!shell_point
 		!shell_particles
+        shell_bone = bolt
 		
 		snd_draw				= weapons\saiga_eft\draw
 		snd_holster				= weapons\saiga_eft\holster


### PR DESCRIPTION
Non-existent bone assigned in `shell_bone` occasionally causes fatal errors upon weapon equip.
Longreed shared a fix for long standing X-16 fatal error caused by companion NPC blocked by restrictor. Tested in Anomaly discord.