### PR TITLE
Streamlined weapon degradation parameters

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/configs/mod_system_zzzzzzzzzz_streamlined_misfire_probability.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/configs/mod_system_zzzzzzzzzz_streamlined_misfire_probability.ltx
@@ -1,20 +1,20 @@
 ; Baseline jam probabilities per weapon class:
 ; 0.0009    manual action/revolvers
 ; 0.0044    pistols (9mm)
-; 0.03      automatic rifles/MG/SMG (5,45x39/9mm)
+; 0.003     automatic rifles/MG/SMG (5,45x39/9mm)
 ; 0.0       launchers/Gauss
 
 ; Differences between weapons of same class are mainly based on damage per shot
 ; oleh5230, 17.06.2025
 
 ![default_weapon_params]
-misfire_probability                     = 0.005    ; not used
-misfire_start_condition                 = 0.83
-misfire_start_prob                      = 0.003
-misfire_end_condition                   = 0.1
-misfire_end_prob                        = 0.1
-condition_queue_shot_dec                = 0.0008
-condition_shot_dec                      = 0.0008
+misfire_probability                     = 0.005     ; unused
+misfire_start_condition                 = 0.83      ; can be changed to batch edit jam probability for all guns
+misfire_start_prob                      = 0.003     ; base jam probability
+misfire_end_condition                   = 0.1       ; unused in GAMMA
+misfire_end_prob                        = 0.1       ; unused in GAMMA
+condition_queue_shot_dec                = 0.0008    ; misfire_start_prob * 0.27 (except for manual action/revolvers)
+condition_shot_dec                      = 0.0008    ; same as condition_queue_shot_dec
 
 ![wpn_mp412]
 !misfire_probablity
@@ -22,48 +22,64 @@ condition_shot_dec                      = 0.0008
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_mp412_ac10632]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_mp412_c-more]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_mp412_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_mp412_march_f_shorty]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_mp412_t12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_revolver357]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0024
+condition_shot_dec                      = 0.0024
 ![wpn_eft_rsh12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.003
+condition_shot_dec                      = 0.003
 
 ![wpn_aps]
 !misfire_probablity
@@ -71,72 +87,96 @@ misfire_start_prob                      = 0.0009
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_aps_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_aps_bas_apsabigo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_modern_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_modern_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_modern_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_beretta_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_colt1911_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_camo]
 !misfire_probablity
 !misfire_start_condition
@@ -149,720 +189,960 @@ misfire_start_prob                      = 0.0112
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_duty]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_new]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_merc]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_colt1911_n]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_cz52]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_cz75]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_cz75_auto]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_desert_eagle_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_acog]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_lazup_pl15]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_march_f_shorty]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_nimble_t12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_desert_eagle_steppe]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.01
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0027
+condition_shot_dec                      = 0.0027
 ![wpn_fn57]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_aim_low]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_e0t2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_kemper]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_compm4s]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_rakurs]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_0kp2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_c-more]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_ac10632]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_ekp8_18]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_mepro]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_aimpoint_pro]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_aimpoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fn57_eot]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.005
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_fnx45]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_fnx45_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_fnx45_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_fnp45_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_fnp45]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_fort_snag]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_fort]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fort17]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_glock_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_c-more]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_eot]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_e0t2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_ac10632]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_aim_low]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_glock17_m1_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_gsh18]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_gsh18_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_hpsa]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_hpsa_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_mp443]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_korth]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_korth_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_korth_custom_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_korth_custom_c-more]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_korth_custom_e0t2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_oc33]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pb]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pb_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pb_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pb_bas_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm_actor]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pmm]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm_bas_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm_bas_actor]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pmm_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pm_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0036
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_pl15]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pl15_pl15_scolaz]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pl15_lazup_pl15]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pl15_tan]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pl15_tan_pl15_scolaz]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_pl15_tan_lazup_pl15]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_sig220_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sig220_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sig220]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sig220_n]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sig220_n_upg220]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sig220_n_u2p2g0r]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_sig226]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_sig226_226sig_kit]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_sr1m]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sr1m_gurza_up]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_sr1m_sr1upgr1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_tt33_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_tt33]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_usp_match]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_usp_tac_45]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac_45_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac_45_aim_low]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac_45_d0cter]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac_45_deltapoint]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_usp_tac_45_rmr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0056
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0015
+condition_shot_dec                      = 0.0015
 ![wpn_walther]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_walther_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_walther_p99]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_walther_p99_mod9]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0044
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 
 ![wpn_9a91]
 !misfire_probablity
@@ -870,1074 +1150,1432 @@ misfire_start_prob                      = 0.0044
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_abakan_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0045
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_abakan_n]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0045
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_abakan]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0045
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0012
+condition_shot_dec                      = 0.0012
 ![wpn_ace21]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ace52]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0053
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0014
+condition_shot_dec                      = 0.0014
 ![wpn_adar2_15]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_aek_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_aek_duty]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_aek]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_ak]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak101_camo]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak101]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak102]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak103_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak103]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak104_alfa]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak104]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak105_bas]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak105_dummy]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak105_shakal]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak105_sp]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak105_swamp]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak105]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak12_custom_mono_kit]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak12_custom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak12_m1]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak12]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak5c_bas_5c_tik]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak5c_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak5c_isg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak74_alt]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_custom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_isg]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_modern]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_n]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_old]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_pmc]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74_rpk]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_alt]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_beard]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_camo]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_custom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_duty]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m_n]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74m]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_camo]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_custom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_isg]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_m1_isg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_ak74u_n1]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_old]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_snag]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u_tac]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ak74u]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_akm_alfa]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akm_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akm_isg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akm]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akms_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akms_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_akms]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_aks]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_aks74_new]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_aks74]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_am17]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_amb17]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_ar15_freedom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_ash12_sup]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_ash12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_aug_a1_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_a1_custom_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_a3_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_a3_custom_bas]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_a3]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_freedom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_aug_merc]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_aug]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_benelli_m1014]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_bizon]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_bm16_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_bm16_full_alt_23]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_bm16_full_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_bm16_full]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_bm16]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_brn180]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_dtmdr_black_sup]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_dtmdr_black]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_dtmdr_sup]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_dtmdr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_dvl10_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_dvl10]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_fal_aus_kit_aus_tri]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_fal_aus_kit_fal_leup]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_fal_aus_kit_sa5x_spec]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_fal_aus]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_fal_sa58_osw]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_fal]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_famas3]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fn2000_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fn2000_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fn2000_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fn2000]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_fnc]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_fort500]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_g3]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_g36_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36c_rwap]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36k_rwap]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36k]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36ka4_rwap]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36nimble_rwap]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g36v_rwap]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_g3sg1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_g43]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_galil_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0053
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0014
+condition_shot_dec                      = 0.0014
 ![wpn_galil_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0053
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0014
+condition_shot_dec                      = 0.0014
 ![wpn_galil]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0053
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0014
+condition_shot_dec                      = 0.0014
 ![wpn_gauss_quest]
 !misfire_probablity
 misfire_start_condition                 = 0.7
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_gauss]
 !misfire_probablity
 misfire_start_condition                 = 0.7
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_groza_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.003
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0008
+condition_shot_dec                      = 0.0008
 ![wpn_groza]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0043
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_hk416]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_hk417]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.007
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0019
+condition_shot_dec                      = 0.0019
 ![wpn_howa20]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_ithacam37_mag]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_ithacam37_sawnoff]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_ithacam37_stakeout_20x70]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_ithacam37_stakeout]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_ithacam37_trench]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_ithacam37]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_k98_mauser_kit]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_k98_mod_silen98]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_k98_mod]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_k98]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_kiparis]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_kriss_vector]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_ks23_23_up]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_ks23_ecolog]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_ks23_kaban_kab_up]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_ks23_kaban]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_ks23]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_ksg23]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_l85_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_l85_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_l85_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85_m2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85_m3]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_l85]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_l85a2_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85a2_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85a2_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l85a2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_l96a1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_l96a1m]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_lr300_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_lr300_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_lr300]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m16]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_m16a2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m24]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_m249]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.002
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_m4_butcher]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4_ru556]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4_tac]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4a1_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4a1_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4a1_freedom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4a1_siber]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m4a1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_m60]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_m79]
 !misfire_probablity
 misfire_start_condition                 = 0.7
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_m82]
 !misfire_probablity
 !misfire_start_condition
@@ -1950,12 +2588,16 @@ misfire_start_prob                      = 0.016
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_mat49]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_mjolnir]
 !misfire_probablity
 !misfire_start_condition
@@ -1968,6 +2610,8 @@ misfire_start_prob                      = 0.015
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_mk47]
 !misfire_probablity
 !misfire_start_condition
@@ -1980,48 +2624,64 @@ misfire_start_prob                      = 0.0045
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_mossberg590_rail]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_mossberg590_wood]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_mossberg590]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_mp133]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_mp153_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_mp153]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_mp155]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_mp5_alt]
 !misfire_probablity
 !misfire_start_condition
@@ -2040,6 +2700,8 @@ misfire_start_prob                      = 0.0027
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_mp5]
 !misfire_probablity
 !misfire_start_condition
@@ -2076,198 +2738,264 @@ misfire_start_prob                      = 0.0034
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_p90_gs]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_p90]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_p90gamma]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_p90tac]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_pkm_siber]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pkm_zenit_siber]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pkm_zulus]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pkm]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pkp_siber]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.002
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pkp]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.002
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pp2000_operator]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_pp2000]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ppsh41_rednew]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ppsh41_woodnew]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_ppsh41]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_protecta_aim]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_protecta_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_protecta_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_protecta_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_protecta]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_raptr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_remington700_archangel]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_remington700_lapua700]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_remington700_magpul_pro]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_remington700_mod_x_gen3]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_remington700]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_remington870]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_rg-6]
 !misfire_probablity
 misfire_start_condition                  = 0.7
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_rpd]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_rpg7]
 !misfire_probablity
 misfire_start_condition                 = 0.7
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_rpk]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0035
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_rpk74_16_drum]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.003
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0008
+condition_shot_dec                      = 0.0008
 !condition_queue_shot_dec
 !condition_shot_dec
 ![wpn_rpk74_16]
@@ -2276,561 +3004,749 @@ misfire_start_prob                      = 0.003
 misfire_start_prob                      = 0.003
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0008
+condition_shot_dec                      = 0.0008
 ![wpn_rpk74]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.003
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0008
+condition_shot_dec                      = 0.0008
 ![wpn_saiga12s_isg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_saiga12s_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_saiga12s_m2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_saiga12s]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_scar_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_new]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber_black]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber_m1_black]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber_m2_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber_m2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar_siber]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_scar]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_sig550_camo]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sig550_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sig550_luckygun]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sig550_sniper]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sig550]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sig552]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0033
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0009
+condition_shot_dec                      = 0.0009
 ![wpn_sks_b]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_sks_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_sks_molot]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_sks_tac]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_sks]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_spas12_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_spas12_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_spas12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_sr2_m1_kp_sr2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_sr2_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_sr2_veresk_kp_sr2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_sr2_veresk_sr2_upkit]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_sr2_veresk]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_sr25]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.007
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0019
+condition_shot_dec                      = 0.0019
 ![wpn_steyr_scout_big]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_steyr_scout]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_sv98_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_sv98]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_svd_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svd_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svd_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svd]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svds_pmc]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svds]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svt40_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svt40]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svu_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svu_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_svu]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_thompson_1921]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_thompson_m1a1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_toz106_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz106]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_bull]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_decor]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_mark4_23]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_toz34_mark4]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_obrez_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_obrez_decor]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34_obrez]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_toz34]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_trg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0014 ;high caliber
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.006
+condition_shot_dec                      = 0.006
 ![wpn_type63]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0047
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0013
+condition_shot_dec                      = 0.0013
 ![wpn_udp9]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_ump45_custom]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_ump45]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0038
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001
 ![wpn_usas12]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_val_modern]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_val_tac]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_val]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vepr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.012
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0032
+condition_shot_dec                      = 0.0032
 ![wpn_vihr]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_alt]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_isg]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_m1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_m2]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_n1]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez_nimble]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vintorez]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vityaz]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_vsk94]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.006
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0016
+condition_shot_dec                      = 0.0016
 ![wpn_vssk]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_vz61_alt]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_vz61_camo]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_vz61_freedom]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_vz61]
 !misfire_probablity
 !misfire_start_condition
 !misfire_start_prob
 !misfire_end_condition
 !misfire_end_prob
+!condition_queue_shot_dec
+!condition_shot_dec
 ![wpn_wa2000]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.008
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0022
+condition_shot_dec                      = 0.0022
 ![wpn_wincheaster1300_trapper]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_wincheaster1300]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_winchester1873]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0009 ;manual action
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.004
+condition_shot_dec                      = 0.004
 ![wpn_xm4]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.004
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.0011
+condition_shot_dec                      = 0.0011
 ![wpn_xm8]
 !misfire_probablity
 !misfire_start_condition
 misfire_start_prob                      = 0.0037
 !misfire_end_condition
 !misfire_end_prob
+condition_queue_shot_dec                = 0.001
+condition_shot_dec                      = 0.001


### PR DESCRIPTION
Changes `condition_shot_dec` parameters accordingly to previously streamlined jam probabilities.
Weapons with small fire rate use 0.004-0.006, close to vanilla values.