### PR TITLE
Knife degradation fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
@@ -76,7 +76,7 @@ x_device_pda_3				     = 3, recipe_expert_2, device_pda_2,1,prt_i_resistors,13,p
 [2]
 title						= st_ui_craft_equipment
 x_itm_backpack			    = 1, recipe_basic_1, sewing_thread,3,prt_o_fabrics_1,4,prt_o_fabrics_3,4
-x_kit_hunt				    = 1, recipe_basic_1, sewing_thread,12,prt_o_fabrics_4,8,swiss_knife,8,wpn_knife2,1
+x_kit_hunt				    = 1, recipe_basic_1, sewing_thread,12,prt_o_fabrics_4,8,swiss_knife,8,wpn_knife,1
 x_equ_small_pack            = 1, recipe_basic_1, sewing_thread,8,itm_backpack,1,prt_o_fabrics_3,8,prt_o_fabrics_2,4
 x_equ_small_military_pack   = 2, recipe_advanced_1, sewing_thread,10,equ_small_pack,1,prt_o_fabrics_4,10,prt_o_fabrics_3,10
 x_equ_military_pack         = 2, recipe_advanced_1, sewing_thread,12,equ_small_military_pack,1,prt_o_fabrics_4,13,prt_o_fabrics_3,12

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/quickdraw.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/quickdraw.script
@@ -123,12 +123,14 @@ function hit_key()
 		return
 	end
 
+	--[[
 	cond = knife_to_degrade:condition()
 	if cond > 0.02 then
 		knife_to_degrade:set_condition(cond - 0.0025)
 	else
 		knife_to_degrade:set_condition(0.01)
 	end
+	]]
 
 	-- end test
 	

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/scripts/item_knife.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/scripts/item_knife.script
@@ -1,5 +1,6 @@
 --[[
 	Modified by Faustle (2018)
+    Modified by xCoiotex --// function degradate() (21/07/2025)
 ]]--
 
 local strong_monster = { 'chimera', 'gigant' }
@@ -26,7 +27,7 @@ local knifesm = {
 					"wpn_knife2"
 				 }
 
---// Функция проверки наличия ножа или топора в руках
+--// function to check if a knife or axe is equipped
 function is_equipped()
 	if (db.actor) then
 		for knind = 1, 9 do
@@ -40,7 +41,7 @@ function is_equipped()
 	return false
 end
 
---// Функция получения состояние текущего оружия
+--// function to get the condition of the current weapon
 function get_condition()
 	if (is_equipped()) then
 		for knind = 1, 9 do
@@ -52,7 +53,7 @@ function get_condition()
 	end
 end
 
---// Функция проверки возможности лута монстра
+--// function to check if the monster can be looted
 function can_loot(monster)
 	if not (monster) then
 		return
@@ -80,31 +81,29 @@ function can_loot(monster)
 	return true
 end
 
---// Функция уменьшения состояния для ножа\топора
+--// Function to degrade knife condition
 function degradate()
-		local num = 0
-		for knind = 1, 9 do
-			local obj = db.actor:object(knifesm[knind])	
-			if obj ~= nil then
-				local cond = obj:condition()
-				local wpn = obj:section()
+    local num = 0
+    for knind = 1, #knifesm do
+        local obj = db.actor:object(knifesm[knind])
+        if obj ~= nil then
+            local cond = obj:condition()
+            local wpn = obj:section()
 
-				if knifes[wpn] then
-					num = knifes[wpn]
-				end
+            if knifes[wpn] then
+                num = knifes[wpn]
+            end
 
-				if (cond > num) then 
-					obj:set_condition(cond-num/4) 
-				else
-					obj:set_condition(0.01)
-				end
-			else
-				return
-			end
-		end
+            if (cond > num) then
+                obj:set_condition(cond - num / 4)
+            else
+                obj:set_condition(0.01)
+            end
+        end
+    end
 end
 
---// Является ли оружие в руках топором
+--// Weapon in hand is an axe?
 function is_axe()
 		for knind = 1, 9 do
 			local obj = db.actor:object(knifesm[knind])	

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/scripts/item_knife.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Cooking Overhaul/gamedata/scripts/item_knife.script
@@ -16,15 +16,15 @@ local knifes = {
 					wpn_knife9 = 0.04
 				 }
 local knifesm = { 
-					"wpn_knife3",
-					"wpn_knife4",
-					"wpn_knife5",
-					"wpn_knife6",
-					"wpn_knife7",
-					"wpn_knife8",
 					"wpn_knife9",
-					"wpn_knife",
-					"wpn_knife2"
+					"wpn_knife8",
+					"wpn_knife7",
+					"wpn_knife6",
+					"wpn_knife5",
+					"wpn_knife4",
+					"wpn_knife3",
+					"wpn_knife2",
+					"wpn_knife"
 				 }
 
 --// function to check if a knife or axe is equipped
@@ -99,6 +99,7 @@ function degradate()
             else
                 obj:set_condition(0.01)
             end
+			break
         end
     end
 end

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Loadouts/gamedata/configs/items/settings/new_game_loadouts.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Starting Loadouts/gamedata/configs/items/settings/new_game_loadouts.ltx
@@ -37,7 +37,7 @@ itm_actor_backpack			    = false,1,0
 itm_backpack			        = false,1,0
 detector_simple			        = false,1,0
 detector_radio					= false,1,0
-wpn_knife2					    = false,1,0
+wpn_knife					    = false,1,0
 bolts_pack						= false,2,0
 picture_woman                   = false,1,0
 


### PR DESCRIPTION
Haven't tested much, but it's a one line fix, what could go wrong.
Restored 6N4 because it has a better model.
Disabled quick melee degradation because regular hits don't degrade knives.