### PR TITLE
Better generic firemode switch animation

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Camera reanimation fixes/gamedata/scripts/camera_reanim_project.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Camera reanimation fixes/gamedata/scripts/camera_reanim_project.script
@@ -60,6 +60,7 @@ end
 
 function play_switch_anm()
     local wpn = db.actor:active_item()
+	if not wpn then return end
 
     if not is_supported_weapon(wpn) then
         return
@@ -74,8 +75,13 @@ function play_switch_anm()
     if not has_multiple_fire_modes(sec) then
         return
     end
-  
-    level.add_cam_effector("camera_effects\\fmode_crp.anm", 1912, false, "", 0, false)
+
+	if has_own_switch_animation(sec) then
+		return
+	end
+
+	game.play_hud_anm("camera_effects\\fmode_crp.anm", 2, 2, 1, false, false)
+    --level.add_cam_effector("camera_effects\\fmode_crp.anm", 1912, false, "", 0, false)
 end
 
 function is_supported_weapon(wpn)
@@ -85,6 +91,15 @@ end
 function is_weapon_ready(wpn)
     local state = wpn:get_state()
     return state == 0 -- eIdle
+end
+
+function has_own_switch_animation(sec)
+	local hud = sec and ini_sys:r_string_ex(sec, "hud")
+    if hud and ini_sys:r_string_ex(hud, "anm_switch_mode") then
+        return true
+    end
+
+    return false
 end
 
 function has_multiple_fire_modes(sec)
@@ -146,7 +161,8 @@ end
 
 local function actor_on_weapon_jammed()
 	if weapon_jammed then 
-		level.add_cam_effector("camera_effects\\jammed_crp.anm", 1913, false, "", 0, false)
+		game.play_hud_anm("camera_effects\\fmode_crp.anm", 2, 2, 1, false, false)
+		--level.add_cam_effector("camera_effects\\jammed_crp.anm", 1913, false, "", 0, false)
 	end
 end
 


### PR DESCRIPTION
Applies the animation to viewmodel instead of camera.
Also doesn't apply generic animation if weapon has a unique one.