### PR TITLE
Increase default Weapon Cover Tilt speed

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. MCM values - Rename to keep your personal changes/gamedata/configs/axr_options.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. MCM values - Rename to keep your personal changes/gamedata/configs/axr_options.ltx
@@ -1313,7 +1313,7 @@
         unusable_parts_handler/sell_parts = true
         unusable_parts_handler/weapon_part_condition_threshold = 40
         weapon_cover_tilt/animation_speed = 10
-        weapon_cover_tilt/animation_weight_coeff = 1.5
+        weapon_cover_tilt/animation_weight_coeff = 1.1
         weapon_cover_tilt/consider_silencer = true
         weapon_cover_tilt/enable_manual_tilt = false
         weapon_cover_tilt/enabled        = true


### PR DESCRIPTION
Old weight factor is a bit exaggerated now that barrel length has proper effect on cover tilt radius.
Also improves sound synchronization and reduces sound distortion.