### PR TITLE
Improve junk items variety in southern stashes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Expert toolkits tier 5/gamedata/configs/items/settings/grok_items_tier.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Expert toolkits tier 5/gamedata/configs/items/settings/grok_items_tier.ltx
@@ -758,6 +758,8 @@ tier = 2
 tier = 2
 [wpn_toz34_obrez]
 tier = 2
+[wpn_toz34_mark4_23]
+tier = 3
 [wpn_wincheaster1300]
 tier = 3
 [wpn_remington870]
@@ -1533,6 +1535,8 @@ tier = 6
 tier = 4
 [ammo_7.62x54_ap]
 tier = 6
+[ammo_gauss]
+tier = 6
 [ammo_vog-25]
 tier = 4
 [ammo_m209]
@@ -1547,8 +1551,6 @@ tier = 3
 tier = 4
 [ammo_20x70_buck]
 tier = 2
-[wpn_toz34_mark4_23]
-tier = 3
 ;-- Explosives
 
 [mine_new]
@@ -1880,15 +1882,15 @@ tier = 2
 [batteries_dead]
 tier = 1
 [grooming]
-tier = 3
+tier = 1
 [swiss_knife]
 tier = 2
 [leatherman_tool]
 tier = 3
 [money_600_700]
-tier = 4
-[money_300_400]
 tier = 3
+[money_300_400]
+tier = 2
 [itm_sleepbag]
 tier = 3
 
@@ -1932,7 +1934,7 @@ tier = 5
 ;-- Misc
 
 [hand_watch]
-tier = 3
+tier = 2
 [jar]
 tier = 1
 [ball_hammer]
@@ -1940,39 +1942,39 @@ tier = 2
 [duct_tape]
 tier = 2
 [e_syringe]
-tier = 2
+tier = 1
 [steel_wool]
 tier = 2
 [jewelry_box]
-tier = 4
+tier = 3
 [porn]
 tier = 2
 [porn2]
-tier = 3
+tier = 2
 [rope]
 tier = 2
 [cutlery]
-tier = 2
+tier = 1
 [tarpaulin]
 tier = 2
 [roubles]
-tier = 2
+tier = 1
 [underwear]
 tier = 1
 [beadspread]
-tier = 2
+tier = 1
 [cards]
-tier = 2
+tier = 1
 [boots]
 tier = 2
 [gloves]
-tier = 2
+tier = 1
 [mirror]
 tier = 1
 [welding_goggles]
-tier = 2
+tier = 1
 [grease]
-tier = 3
+tier = 2
 [picture_woman]
 tier = 1
 [broken_detector]
@@ -2271,21 +2273,21 @@ tier = 4
 [prt_i_paper]
 tier = 2
 [prt_i_textolite]
-tier = 3
+tier = 2
 [prt_i_capacitors]
-tier = 3
+tier = 2
 [prt_i_transistors]
-tier = 3
+tier = 1
 [prt_i_resistors]
-tier = 3
+tier = 1
 [prt_i_copper]
-tier = 3
+tier = 2
 [prt_i_scrap]
-tier = 3
+tier = 1
 [prt_i_fasteners]
-tier = 3
+tier = 1
 [prt_i_plastic]
-tier = 3
+tier = 1
 
 
 


### PR DESCRIPTION
In brief, puts most basic materials in 1st tier and most junk items in 2nd tier to improve variety (currently almost every Cordon stash drops a mirror or a jar, for example).

Also assigns tier 6 to Gauss ammo, should make them as rare as other best AP ammo I think.