### PR TITLE
Fix spelling of Dux's Innumerable Characters Kit to match archive folder

### DIFF
--- a/G.A.M.M.A/modpack_data/modpack_maker_list.txt
+++ b/G.A.M.M.A/modpack_data/modpack_maker_list.txt
@@ -26,8 +26,8 @@ https://www.moddb.com/addons/start/184325	0	 - Bazingarrey	 High Res Loading Scr
 https://www.moddb.com/addons/start/184227	High Res PDA Maps	 - Bazingarrey	 High Res PDA Maps	https://www.moddb.com/mods/stalker-anomaly/addons/high-resolution-maps
 https://www.moddb.com/addons/start/216034	0	 - Tweaki_Breeki	 Fairer Thermal Anomalies	https://www.moddb.com/mods/stalker-anomaly/addons/tbs-fairer-thermal-anomalies-v1-0
 https://www.moddb.com/addons/start/219214	21 game\CORE	 - Feel_Fried	 Black Jack	https://www.moddb.com/mods/stalker-anomaly/addons/blackjack-21-engrus-151
-https://www.moddb.com/addons/start/208861	2.0.0	 - DuxFortis	 Dux's Innemurable Characters Kit	https://www.moddb.com/mods/stalker-anomaly/addons/dick
-https://www.moddb.com/addons/start/208861	2.0.0\Dux's Innumerable Character Kit - Blackjack Patch	 - DuxFortis	 Dux's Innemurable Characters Kit Blackjack patch	https://www.moddb.com/mods/stalker-anomaly/addons/dick
+https://www.moddb.com/addons/start/208861	2.0.0	 - DuxFortis	 Dux's Innumurable Characters Kit	https://www.moddb.com/mods/stalker-anomaly/addons/dick
+https://www.moddb.com/addons/start/208861	2.0.0\Dux's Innumerable Character Kit - Blackjack Patch	 - DuxFortis	 Dux's Innumurable Characters Kit Blackjack patch	https://www.moddb.com/mods/stalker-anomaly/addons/dick
 https://www.moddb.com/addons/start/222685	addons\UNISG Overhaul:addons\SEVA Glass Variety	 - Blackgrowl	 Fixed Vanilla Models and Textures	https://www.moddb.com/mods/stalker-anomaly/addons/fvm
 https://www.moddb.com/addons/start/227255	01 MAIN	 - Blackgrowl	 FVM Nosorogs models	https://www.moddb.com/mods/stalker-anomaly/addons/fvm-nosorogoverhaul
 https://www.moddb.com/addons/start/227529	HDMutants	 - Umbrellord	 HD mutant models and textures	https://www.moddb.com/mods/stalker-anomaly/addons/umbrellords-hd-mutant-models-wip


### PR DESCRIPTION
My bad if I've done this wrong, it's literally my first ever PR. 

This fixed the error below for me after testing on my install. It's just an archive name mismatch, leading to an empty gamedata folder in the GAMMA/mods folder for 29 & 30.

`Expression    : no_assert
Function      : CXML_IdToIndex<class CCharacterInfo>::GetById
File          : D:\a\xray-monolith\xray-monolith\src\xrServerEntities\xml_str_id_loader.h
Line          : 114
Description   : item not found, id
Arguments     : sim_default_zombied_0`