### PR TITLE
DICK 2.0.1 folder structure revertion to pre-2.0 update standard

### DIFF
--- a/G.A.M.M.A/modpack_data/modpack_maker_list.txt
+++ b/G.A.M.M.A/modpack_data/modpack_maker_list.txt
@@ -26,8 +26,8 @@ https://www.moddb.com/addons/start/184325	0	 - Bazingarrey	 High Res Loading Scr
 https://www.moddb.com/addons/start/184227	High Res PDA Maps	 - Bazingarrey	 High Res PDA Maps	https://www.moddb.com/mods/stalker-anomaly/addons/high-resolution-maps
 https://www.moddb.com/addons/start/216034	0	 - Tweaki_Breeki	 Fairer Thermal Anomalies	https://www.moddb.com/mods/stalker-anomaly/addons/tbs-fairer-thermal-anomalies-v1-0
 https://www.moddb.com/addons/start/219214	21 game\CORE	 - Feel_Fried	 Black Jack	https://www.moddb.com/mods/stalker-anomaly/addons/blackjack-21-engrus-151
-https://www.moddb.com/addons/start/208861	2.0.0	 - DuxFortis	 Dux's Innemurable Characters Kit	https://www.moddb.com/mods/stalker-anomaly/addons/dick
-https://www.moddb.com/addons/start/208861	2.0.0\Dux's Innumerable Character Kit - Blackjack Patch	 - DuxFortis	 Dux's Innemurable Characters Kit Blackjack patch	https://www.moddb.com/mods/stalker-anomaly/addons/dick
+https://www.moddb.com/addons/start/208861	Dux's Innumerable Character Kit	 - DuxFortis	 Dux's Innemurable Characters Kit	https://www.moddb.com/mods/stalker-anomaly/addons/dick
+https://www.moddb.com/addons/start/208861	Dux's Innumerable Character Kit\Dux's Innumerable Character Kit - Blackjack Patch	 - DuxFortis	 Dux's Innemurable Characters Kit Blackjack patch	https://www.moddb.com/mods/stalker-anomaly/addons/dick
 https://www.moddb.com/addons/start/222685	addons\UNISG Overhaul:addons\SEVA Glass Variety	 - Blackgrowl	 Fixed Vanilla Models and Textures	https://www.moddb.com/mods/stalker-anomaly/addons/fvm
 https://www.moddb.com/addons/start/227255	01 MAIN	 - Blackgrowl	 FVM Nosorogs models	https://www.moddb.com/mods/stalker-anomaly/addons/fvm-nosorogoverhaul
 https://www.moddb.com/addons/start/227529	HDMutants	 - Umbrellord	 HD mutant models and textures	https://www.moddb.com/mods/stalker-anomaly/addons/umbrellords-hd-mutant-models-wip


### PR DESCRIPTION
We mistakingly renamed the internal folder of the zip in v2.0 update, we reverted back to non-versioned folder name

Previous BAS patch is no longer important since all it did was adjusted equipment of Dux's special squads that have no way to naturally spawn in the game, only through console