### PR TITLE
Milspec pda shows allies

### DIFF
--- a/G.A.M.M.A/modpack_addons/SaloEater's Milspec PDA shows allies/gamedata/configs/text/rus/st_milspec_shows_allies.xml
+++ b/G.A.M.M.A/modpack_addons/SaloEater's Milspec PDA shows allies/gamedata/configs/text/rus/st_milspec_shows_allies.xml
@@ -1,11 +1,11 @@
 <string_table>
-	<string id="ui_mcm_milpda_milpdagen_allies_mode">
-        <text>РљР°РєРёРµ СЃРѕСЋР·РЅС‹Рµ С„СЂР°РєС†РёРё Р±СѓРґСѓС‚ РІРёРґРЅС‹ РЅР° РєР°СЂС‚Рµ</text>
+    <string id="ui_mcm_milpda_milpdagen_allies_mode">
+        <text>Какие союзные фракции будут видны на карте</text>
     </string>
     <string id="ui_mcm_lst_milpda_allies_mode_faction">
-        <text>РЎРѕСЋР·РЅС‹Рµ РІР°С€РµР№ С„СЂР°РєС†РёРё</text>
+        <text>Союзные вашей фракции</text>
     </string>
     <string id="ui_mcm_lst_milpda_allies_mode_personal">
-        <text>РЎРѕСЋР·РЅС‹Рµ Р»РёС‡РЅРѕ РІР°Рј</text>
+        <text>Союзные лично вам</text>
     </string>
 </string_table>


### PR DESCRIPTION
Right now Milspec PDA shows only faction allies (regenages can't see csky squads on the map) and this PR adds an option to MCM to switch that to personal allies (renegades can see csky squads on the map if reputation is neutral i.e. >-999)
Video - https://discord.com/channels/912320241713958912/1347713127298498560

PR to milspec - https://github.com/CatspawMods/Anomaly-Addon-Archive/pull/5

Catspaw told me he would accept PR when he is back to modding, so added a killswitch until he releases a new version