### PR TITLE
Fix typo in modlist.txt

### DIFF
--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -196,7 +196,7 @@
 +Demonized FDDA New Time Events
 +Darkasleif's Text Edits
 +Darkasleif's Stop Selling Documents
-+DarkasleQif's and iTheon's Parts Condition Color Thresholds Changes
++Darkasleif's and iTheon's Parts Condition Color Thresholds Changes
 +Darkasleif's Nimble Upgrades Guns
 +Darkasleif's More Vodka Trades
 +Darkasleif's Cars Fixes


### PR DESCRIPTION
The correct mod is downloaded but the typo causes it to be inactive in MO2