### PR TITLE
Fix recent artefact spawn timer delay change

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/grok_artefacts_random_spawner.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/scripts/grok_artefacts_random_spawner.script
@@ -32,8 +32,8 @@ function grok_artefact_spawner()
     tg = time_global()
 
     if spawned == 0 then
-		delay1 = delay1 * 1.2 or 22687
-		delay2 = delay2 * 1.2 or 54264
+		delay1 = delay1 * 1.2
+		delay2 = delay2 * 1.2
 		delay = math.random(delay1,delay2)
         grok_delay = tg + delay
 		printf("Spawning artefacts in %s",delay)
@@ -83,14 +83,9 @@ function set_delay()
 	local actor_level = sim:level_name(gg:vertex(sim:actor().m_game_vertex_id):level_id())
 	printf(actor_level)
 
-	if map_previous_name then
-		if map_previous_name ~= actor_level then
-			delay1 = 30250
-			delay2 = 77520
-		end
-	else
-		delay1 = 30250
-		delay2 = 77520
+	if (not map_previous_name) or (map_previous_name ~= actor_level) then
+		delay1 = 22687
+		delay2 = 54264
 	end
 	
 	map_previous_name = actor_level


### PR DESCRIPTION
The lowered spawn timer values from [Less delay between artefacts spawn + higher regular spawn chance + reduced dynamic spawn chance](https://github.com/v1ld/Stalker_GAMMA/commit/3104027431d9855d17f4d23cc985dc97cedc9721) weren't taking effect: `delay1` and `delay2` could not be `nil` there or it would have thrown a "nil value used in math" exception.

This patch lowers those values in `set_delay()` instead and removes the duplicated logic for their initialization.