### PR TITLE
prevent infinity time event loops

### DIFF
--- a/G.A.M.M.A/modpack_addons/SaloEater's Keep Crafting Window Opened remembers HFE's stove crafting slot/gamedata/scripts/zz_item_cooking_keep_crafting_window_open_remember_hfe_stove_slot.script
+++ b/G.A.M.M.A/modpack_addons/SaloEater's Keep Crafting Window Opened remembers HFE's stove crafting slot/gamedata/scripts/zz_item_cooking_keep_crafting_window_open_remember_hfe_stove_slot.script
@@ -2,10 +2,11 @@ local stove_opened = false
 
 local old_item_cooking_UICook_CollectValidItems = item_cooking.UICook.CollectValidItems
 function item_cooking.UICook.CollectValidItems(self, obj, section)
-    old_item_cooking_UICook_CollectValidItems(self, obj, section)
+    local ret = old_item_cooking_UICook_CollectValidItems(self, obj, section)
     if stove_opened then
         self.multiUseItemsUses = self.multiUseItemsUses + 1
     end
+    return ret
 end
 
 local old_OpenCookUI = ui_stove_furniture.UICookStove.UseCook


### PR DESCRIPTION
I didn't put enough effort into testing previous PR and that lead to a crash due to time event from demonized mod were updating cooking ui state in advance and that broke the game - https://discord.com/channels/912320241713958912/1436378793525641256

This PR fixes this issue, I'm sorry