### PR TITLE
Fix item_basic_kit reward crash

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Additional Storylines fixes/gamedata/configs/misc/task/mod_task_manager_storylines_dltx.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Additional Storylines fixes/gamedata/configs/misc/task/mod_task_manager_storylines_dltx.ltx
@@ -1591,7 +1591,7 @@ title = {=actor_has_item(main_story_1_quest_case)}kuznec_stry_doc, kuznecov_find
 descr = kuznecov_find_document_1_descr
 target = {=actor_has_item(main_story_1_quest_case)} agr_smart_terrain_1_6_near_2_military_colonel_kovalski, nil
 condlist_0 = {+document_agr_vip_kuznecov} complete
-on_complete = %=complete_task_inc_goodwill(75:army) =reward_stash(true) =reward_random_item(itm_basic_kit) =reward_random_money(3000:4000)%
+on_complete = %=complete_task_inc_goodwill(75:army) =reward_stash(true) =reward_random_item(itm_basickit) =reward_random_money(3000:4000)%
 
 [kuznecov_find_document_2]
 icon = ui_inGame2_Poslednie_razrabotki


### PR DESCRIPTION
Fixes an issue related to https://discord.com/channels/912320241713958912/915515500686086145/1439252612720361555

The actual issue is not autocomplete but that `itm_basic_kit` is actually called `itm_basickit`