### PR TITLE
Fix goodwill loss from dynamic tasks

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Dynamic Tasks Balance/gamedata/configs/misc/task/tm_dynamic.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Dynamic Tasks Balance/gamedata/configs/misc/task/tm_dynamic.ltx
@@ -52,7 +52,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_1)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_1_fetch:supplies:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_1_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(50:csky) =complete_task_inc_goodwill(-15:renegade) =complete_task_inc_goodwill(-15:bandit) =inc_task_stage(simulation_task_1) =pstor_reset(simulation_task_1_fetch) =drx_sl_unregister_task_giver(simulation_task_1) =drx_sl_reset_stored_task(simulation_task_1)%
+on_complete = %=fetch_reward_and_remove(simulation_task_1_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(50:csky) =complete_task_dec_goodwill(15:renegade) =complete_task_dec_goodwill(15:bandit) =inc_task_stage(simulation_task_1) =pstor_reset(simulation_task_1_fetch) =drx_sl_unregister_task_giver(simulation_task_1) =drx_sl_reset_stored_task(simulation_task_1)%
 on_fail = %=fail_task_dec_goodwill(50:csky) =pstor_reset(simulation_task_1_fetch) =drx_sl_unregister_task_giver(simulation_task_1) =drx_sl_reset_stored_task(simulation_task_1)%
 
 
@@ -80,7 +80,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_2)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_2_fetch:supplies:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_2_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:freedom)  =complete_task_inc_goodwill(-15:dolg) =complete_task_inc_goodwill(-15:dolg) =inc_task_stage(simulation_task_2) =pstor_reset(simulation_task_2_fetch) =drx_sl_unregister_task_giver(simulation_task_2) =drx_sl_reset_stored_task(simulation_task_2)%
+on_complete = %=fetch_reward_and_remove(simulation_task_2_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:freedom)  =complete_task_dec_goodwill(15:dolg) =complete_task_dec_goodwill(15:dolg) =inc_task_stage(simulation_task_2) =pstor_reset(simulation_task_2_fetch) =drx_sl_unregister_task_giver(simulation_task_2) =drx_sl_reset_stored_task(simulation_task_2)%
 on_fail = %=fail_task_dec_goodwill(50:freedom) =pstor_reset(simulation_task_2_fetch) =drx_sl_unregister_task_giver(simulation_task_2) =drx_sl_reset_stored_task(simulation_task_2)%
 
 
@@ -108,7 +108,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_3)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_3_fetch:supplies:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_3_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:bandit)  =complete_task_inc_goodwill(-15:stalker) =complete_task_inc_goodwill(-15:csky) =complete_task_inc_goodwill(-15:dolg) =complete_task_inc_goodwill(-15:ecolog) =inc_task_stage(simulation_task_3) =pstor_reset(simulation_task_3_fetch) =drx_sl_unregister_task_giver(simulation_task_3) =drx_sl_reset_stored_task(simulation_task_3)%
+on_complete = %=fetch_reward_and_remove(simulation_task_3_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:bandit)  =complete_task_dec_goodwill(15:stalker) =complete_task_dec_goodwill(15:csky) =complete_task_dec_goodwill(15:dolg) =complete_task_dec_goodwill(15:ecolog) =inc_task_stage(simulation_task_3) =pstor_reset(simulation_task_3_fetch) =drx_sl_unregister_task_giver(simulation_task_3) =drx_sl_reset_stored_task(simulation_task_3)%
 on_fail = %=fail_task_dec_goodwill(50:bandit) =pstor_reset(simulation_task_3_fetch) =drx_sl_unregister_task_giver(simulation_task_3) =drx_sl_reset_stored_task(simulation_task_3)%
 
 
@@ -136,7 +136,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_4)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_4_fetch:supplies:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_4_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_inc_goodwill(-15:stalker) =inc_task_stage(simulation_task_4) =pstor_reset(simulation_task_4_fetch) =drx_sl_unregister_task_giver(simulation_task_4) =drx_sl_reset_stored_task(simulation_task_4)%
+on_complete = %=fetch_reward_and_remove(simulation_task_4_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_dec_goodwill(15:stalker) =inc_task_stage(simulation_task_4) =pstor_reset(simulation_task_4_fetch) =drx_sl_unregister_task_giver(simulation_task_4) =drx_sl_reset_stored_task(simulation_task_4)%
 on_fail = %=fail_task_dec_goodwill(50:army) =pstor_reset(simulation_task_4_fetch) =drx_sl_unregister_task_giver(simulation_task_4) =drx_sl_reset_stored_task(simulation_task_4)%
 
 
@@ -192,7 +192,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_6)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_6_fetch:supplies:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_6_fetch:0.8) =complete_task_inc_goodwill(50:killer) =complete_task_inc_goodwill(-15:stalker) =complete_task_inc_goodwill(-15:dolg) =inc_task_stage(simulation_task_6) =pstor_reset(simulation_task_6_fetch) =drx_sl_unregister_task_giver(simulation_task_6) =drx_sl_reset_stored_task(simulation_task_6)%
+on_complete = %=fetch_reward_and_remove(simulation_task_6_fetch:0.8) =complete_task_inc_goodwill(50:killer) =complete_task_dec_goodwill(15:stalker) =complete_task_dec_goodwill(15:dolg) =inc_task_stage(simulation_task_6) =pstor_reset(simulation_task_6_fetch) =drx_sl_unregister_task_giver(simulation_task_6) =drx_sl_reset_stored_task(simulation_task_6)%
 on_fail = %=fail_task_dec_goodwill(50:killer) =pstor_reset(simulation_task_6_fetch) =drx_sl_unregister_task_giver(simulation_task_6) =drx_sl_reset_stored_task(simulation_task_6)%
 
 
@@ -222,7 +222,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_7)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_7_fetch:weapons:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_7_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_inc_goodwill(-25:bandit) =complete_task_inc_goodwill(-25:renegade) =complete_task_inc_goodwill(-25:killer) =inc_task_stage(simulation_task_7) =pstor_reset(simulation_task_7_fetch) =drx_sl_unregister_task_giver(simulation_task_7) =drx_sl_reset_stored_task(simulation_task_7)%
+on_complete = %=fetch_reward_and_remove(simulation_task_7_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_dec_goodwill(25:bandit) =complete_task_dec_goodwill(25:renegade) =complete_task_dec_goodwill(25:killer) =inc_task_stage(simulation_task_7) =pstor_reset(simulation_task_7_fetch) =drx_sl_unregister_task_giver(simulation_task_7) =drx_sl_reset_stored_task(simulation_task_7)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =pstor_reset(simulation_task_7_fetch) =drx_sl_unregister_task_giver(simulation_task_7) =drx_sl_reset_stored_task(simulation_task_7)%
 
 
@@ -250,7 +250,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_8)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_8_fetch:weapons:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_8_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_inc_goodwill(-25:freedom) =complete_task_inc_goodwill(-25:killer) =complete_task_inc_goodwill(-25:bandit) =inc_task_stage(simulation_task_8) =pstor_reset(simulation_task_8_fetch) =drx_sl_unregister_task_giver(simulation_task_8) =drx_sl_reset_stored_task(simulation_task_8)%
+on_complete = %=fetch_reward_and_remove(simulation_task_8_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_dec_goodwill(25:freedom) =complete_task_dec_goodwill(25:killer) =complete_task_dec_goodwill(25:bandit) =inc_task_stage(simulation_task_8) =pstor_reset(simulation_task_8_fetch) =drx_sl_unregister_task_giver(simulation_task_8) =drx_sl_reset_stored_task(simulation_task_8)%
 on_fail = %=fail_task_dec_goodwill(50:dolg) =pstor_reset(simulation_task_8_fetch) =drx_sl_unregister_task_giver(simulation_task_8) =drx_sl_reset_stored_task(simulation_task_8)%
 
 
@@ -278,7 +278,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_9)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_9_fetch:weapons:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_9_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:bandit) =complete_task_inc_goodwill(-25:stalker) =complete_task_inc_goodwill(-25:csky) =complete_task_inc_goodwill(-25:dolg) =complete_task_inc_goodwill(-25:ecolog) =inc_task_stage(simulation_task_9) =pstor_reset(simulation_task_9_fetch) =drx_sl_unregister_task_giver(simulation_task_9) =drx_sl_reset_stored_task(simulation_task_9)%
+on_complete = %=fetch_reward_and_remove(simulation_task_9_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:bandit) =complete_task_dec_goodwill(25:stalker) =complete_task_dec_goodwill(25:csky) =complete_task_dec_goodwill(25:dolg) =complete_task_dec_goodwill(25:ecolog) =inc_task_stage(simulation_task_9) =pstor_reset(simulation_task_9_fetch) =drx_sl_unregister_task_giver(simulation_task_9) =drx_sl_reset_stored_task(simulation_task_9)%
 on_fail = %=fail_task_dec_goodwill(50:bandit) =pstor_reset(simulation_task_9_fetch) =drx_sl_unregister_task_giver(simulation_task_9) =drx_sl_reset_stored_task(simulation_task_9)%
 
 
@@ -306,7 +306,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_10)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_10_fetch:weapons:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_10_fetch:0.8) =complete_task_inc_goodwill(50:killer) =complete_task_inc_goodwill(-25:stalker) =complete_task_inc_goodwill(-25:dolg) =inc_task_stage(simulation_task_10) =pstor_reset(simulation_task_10_fetch) =drx_sl_unregister_task_giver(simulation_task_10) =drx_sl_reset_stored_task(simulation_task_10)%
+on_complete = %=fetch_reward_and_remove(simulation_task_10_fetch:0.8) =complete_task_inc_goodwill(50:killer) =complete_task_dec_goodwill(25:stalker) =complete_task_dec_goodwill(25:dolg) =inc_task_stage(simulation_task_10) =pstor_reset(simulation_task_10_fetch) =drx_sl_unregister_task_giver(simulation_task_10) =drx_sl_reset_stored_task(simulation_task_10)%
 on_fail = %=fail_task_dec_goodwill(50:killer) =pstor_reset(simulation_task_10_fetch) =drx_sl_unregister_task_giver(simulation_task_10) =drx_sl_reset_stored_task(simulation_task_10)%
 
 
@@ -334,7 +334,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_11)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_11_fetch:weapons:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_11_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_inc_goodwill(-25:stalker) =inc_task_stage(simulation_task_11) =pstor_reset(simulation_task_11_fetch) =drx_sl_unregister_task_giver(simulation_task_11) =drx_sl_reset_stored_task(simulation_task_11)%
+on_complete = %=fetch_reward_and_remove(simulation_task_11_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_dec_goodwill(25:stalker) =inc_task_stage(simulation_task_11) =pstor_reset(simulation_task_11_fetch) =drx_sl_unregister_task_giver(simulation_task_11) =drx_sl_reset_stored_task(simulation_task_11)%
 on_fail = %=fail_task_dec_goodwill(50:army) =pstor_reset(simulation_task_11_fetch) =drx_sl_unregister_task_giver(simulation_task_11) =drx_sl_reset_stored_task(simulation_task_11)%
 
 
@@ -364,7 +364,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_12)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_12_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_12_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_inc_goodwill(-25:bandit) =complete_task_inc_goodwill(-25:renegade) =complete_task_inc_goodwill(-25:killer) =inc_task_stage(simulation_task_12) =pstor_reset(simulation_task_12_fetch) =drx_sl_unregister_task_giver(simulation_task_12) =drx_sl_reset_stored_task(simulation_task_12)%
+on_complete = %=fetch_reward_and_remove(simulation_task_12_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_dec_goodwill(25:bandit) =complete_task_dec_goodwill(25:renegade) =complete_task_dec_goodwill(25:killer) =inc_task_stage(simulation_task_12) =pstor_reset(simulation_task_12_fetch) =drx_sl_unregister_task_giver(simulation_task_12) =drx_sl_reset_stored_task(simulation_task_12)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =pstor_reset(simulation_task_12_fetch) =drx_sl_unregister_task_giver(simulation_task_12) =drx_sl_reset_stored_task(simulation_task_12)%
 
 
@@ -392,7 +392,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_13)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_13_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_13_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_inc_goodwill(-25:stalker) =inc_task_stage(simulation_task_13) =pstor_reset(simulation_task_13_fetch) =drx_sl_unregister_task_giver(simulation_task_13) =drx_sl_reset_stored_task(simulation_task_13)%
+on_complete = %=fetch_reward_and_remove(simulation_task_13_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_dec_goodwill(25:stalker) =inc_task_stage(simulation_task_13) =pstor_reset(simulation_task_13_fetch) =drx_sl_unregister_task_giver(simulation_task_13) =drx_sl_reset_stored_task(simulation_task_13)%
 on_fail = %=fail_task_dec_goodwill(50:army) =pstor_reset(simulation_task_13_fetch) =drx_sl_unregister_task_giver(simulation_task_13) =drx_sl_reset_stored_task(simulation_task_13)%
 
 
@@ -756,7 +756,7 @@ condlist_1 = {!task_giver_alive(simulation_task_26)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_26)%
 on_init = %=setup_companion_task(hostage_companion_task_1_stalker:nil:simulation_task_26:true:true) +hostage_companion_task_1_started%
-on_complete = %=reward_random_money(4000:4500) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_inc_goodwill(-50:bandit) =complete_task_inc_goodwill(-50:renegade) =complete_task_inc_goodwill(-50:killer) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_26) =unlock_smart(simulation_task_26) =drx_sl_unregister_hostage_giver(simulation_task_26) =drx_sl_unregister_task_giver(simulation_task_26) =drx_sl_reset_stored_task(simulation_task_26)%
+on_complete = %=reward_random_money(4000:4500) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_dec_goodwill(50:bandit) =complete_task_dec_goodwill(50:renegade) =complete_task_dec_goodwill(50:killer) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_26) =unlock_smart(simulation_task_26) =drx_sl_unregister_hostage_giver(simulation_task_26) =drx_sl_unregister_task_giver(simulation_task_26) =drx_sl_reset_stored_task(simulation_task_26)%
 on_fail = %=unlock_smart(simulation_task_26) =fail_task_dec_goodwill(50:stalker) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =drx_sl_unregister_hostage_giver(simulation_task_26) =drx_sl_unregister_task_giver(simulation_task_26) =drx_sl_reset_stored_task(simulation_task_26)%
 
 
@@ -784,7 +784,7 @@ condlist_1 = {!task_giver_alive(simulation_task_27)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_27)%
 on_init = %=setup_companion_task(hostage_companion_task_1_dolg:nil:simulation_task_27:true:true) +hostage_companion_task_1_started%
-on_complete = %=reward_random_money(6000:6500) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_inc_goodwill(-50:freedom) =complete_task_inc_goodwill(-50:killer) =complete_task_inc_goodwill(-50:bandit) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_27) =unlock_smart(simulation_task_27) =drx_sl_unregister_hostage_giver(simulation_task_27) =drx_sl_unregister_task_giver(simulation_task_27) =drx_sl_reset_stored_task(simulation_task_27)%
+on_complete = %=reward_random_money(6000:6500) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_dec_goodwill(50:freedom) =complete_task_dec_goodwill(50:killer) =complete_task_dec_goodwill(50:bandit) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_27) =unlock_smart(simulation_task_27) =drx_sl_unregister_hostage_giver(simulation_task_27) =drx_sl_unregister_task_giver(simulation_task_27) =drx_sl_reset_stored_task(simulation_task_27)%
 on_fail = %=unlock_smart(simulation_task_27) =fail_task_dec_goodwill(50:dolg) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =drx_sl_unregister_hostage_giver(simulation_task_27) =drx_sl_unregister_task_giver(simulation_task_27) =drx_sl_reset_stored_task(simulation_task_27)%
 
 
@@ -812,7 +812,7 @@ condlist_1 = {!task_giver_alive(simulation_task_28)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_28)%
 on_init = %=setup_companion_task(hostage_companion_task_1_freedom:nil:simulation_task_28:true:true) +hostage_companion_task_1_started%
-on_complete = %=reward_random_money(6000:6500) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_inc_goodwill(-50:dolg) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_28) =unlock_smart(simulation_task_28) =drx_sl_unregister_hostage_giver(simulation_task_28) =drx_sl_unregister_task_giver(simulation_task_28) =drx_sl_reset_stored_task(simulation_task_28)%
+on_complete = %=reward_random_money(6000:6500) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_dec_goodwill(50:dolg) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_28) =unlock_smart(simulation_task_28) =drx_sl_unregister_hostage_giver(simulation_task_28) =drx_sl_unregister_task_giver(simulation_task_28) =drx_sl_reset_stored_task(simulation_task_28)%
 on_fail = %=unlock_smart(simulation_task_28) =fail_task_dec_goodwill(50:freedom) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =drx_sl_unregister_hostage_giver(simulation_task_28) =drx_sl_unregister_task_giver(simulation_task_28) =drx_sl_reset_stored_task(simulation_task_28)%
 
 
@@ -840,7 +840,7 @@ condlist_1 = {!task_giver_alive(simulation_task_29)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_29)%
 on_init = %=setup_companion_task(hostage_companion_task_1_ecolog:nil:simulation_task_29:true:true) +hostage_companion_task_1_started%
-on_complete = %=reward_random_money(5000:5500) =reward_random_item(stimpack:medkit:morphine:drug_booster:tetanus) =reward_stash(true) =complete_task_inc_goodwill(50:ecolog) =complete_task_inc_goodwill(-50:bandit) =complete_task_inc_goodwill(-50:renegade) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_29) =unlock_smart(simulation_task_29) =drx_sl_unregister_hostage_giver(simulation_task_29) =drx_sl_unregister_task_giver(simulation_task_29) =drx_sl_reset_stored_task(simulation_task_29)%
+on_complete = %=reward_random_money(5000:5500) =reward_random_item(stimpack:medkit:morphine:drug_booster:tetanus) =reward_stash(true) =complete_task_inc_goodwill(50:ecolog) =complete_task_dec_goodwill(50:bandit) =complete_task_dec_goodwill(50:renegade) =remove_special_task_squad(hostage_companion_task_1) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =inc_task_stage(simulation_task_29) =unlock_smart(simulation_task_29) =drx_sl_unregister_hostage_giver(simulation_task_29) =drx_sl_unregister_task_giver(simulation_task_29) =drx_sl_reset_stored_task(simulation_task_29)%
 on_fail = %=unlock_smart(simulation_task_29) =fail_task_dec_goodwill(50:ecolog) -hostage_companion_task_1_hostage_rescued -hostage_companion_task_1_started =drx_sl_unregister_hostage_giver(simulation_task_29) =drx_sl_unregister_task_giver(simulation_task_29) =drx_sl_reset_stored_task(simulation_task_29)%
 
 
@@ -867,7 +867,7 @@ status_functor = bounty_task
 condlist_0 = {!task_giver_alive(simulation_task_30)} fail
 
 on_job_descr = %=setup_bounty_task(simulation_task_30:true:true:stalker)%
-on_complete = %=reward_random_money(5500:6000) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_inc_goodwill(-50:bandit) =complete_task_inc_goodwill(-50:renegade) =complete_task_inc_goodwill(-50:killer) =inc_task_stage(simulation_task_30) =drx_sl_unregister_task_giver(simulation_task_30) =drx_sl_reset_stored_task(simulation_task_30)%
+on_complete = %=reward_random_money(5500:6000) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_stash(true) =complete_task_inc_goodwill(50:stalker)  =complete_task_dec_goodwill(50:bandit) =complete_task_dec_goodwill(50:renegade) =complete_task_dec_goodwill(50:killer) =inc_task_stage(simulation_task_30) =drx_sl_unregister_task_giver(simulation_task_30) =drx_sl_reset_stored_task(simulation_task_30)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =drx_sl_unregister_task_giver(simulation_task_30) =drx_sl_reset_stored_task(simulation_task_30)%
 
 
@@ -892,7 +892,7 @@ status_functor = bounty_task
 condlist_0 = {!task_giver_alive(simulation_task_31)} fail
 
 on_job_descr = %=setup_bounty_task(simulation_task_31:false:true:bandit:renegade:killer)%
-on_complete = %=reward_random_money(5000:5500) =reward_item(vodka2) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_inc_goodwill(-50:bandit) =complete_task_inc_goodwill(-50:renegade) =complete_task_inc_goodwill(-50:killer) =inc_task_stage(simulation_task_31) =drx_sl_unregister_task_giver(simulation_task_31) =drx_sl_reset_stored_task(simulation_task_31)%
+on_complete = %=reward_random_money(5000:5500) =reward_item(vodka2) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_dec_goodwill(50:bandit) =complete_task_dec_goodwill(50:renegade) =complete_task_dec_goodwill(50:killer) =inc_task_stage(simulation_task_31) =drx_sl_unregister_task_giver(simulation_task_31) =drx_sl_reset_stored_task(simulation_task_31)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =drx_sl_unregister_task_giver(simulation_task_31) =drx_sl_reset_stored_task(simulation_task_31)%
 
 
@@ -942,7 +942,7 @@ status_functor = bounty_task
 condlist_0 = {!task_giver_alive(simulation_task_33)} fail
 
 on_job_descr = %=setup_bounty_task(simulation_task_33:false:true:stalker:army:dolg)%
-on_complete = %=reward_random_money(5500:6000) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =complete_task_inc_goodwill(50:killer) =complete_task_inc_goodwill(-50:stalker) =complete_task_inc_goodwill(-50:dolg) =inc_task_stage(simulation_task_33) =drx_sl_unregister_task_giver(simulation_task_33) =drx_sl_reset_stored_task(simulation_task_33)%
+on_complete = %=reward_random_money(5500:6000) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =complete_task_inc_goodwill(50:killer) =complete_task_dec_goodwill(50:stalker) =complete_task_dec_goodwill(50:dolg) =inc_task_stage(simulation_task_33) =drx_sl_unregister_task_giver(simulation_task_33) =drx_sl_reset_stored_task(simulation_task_33)%
 on_fail = %=fail_task_dec_goodwill(50:killer) =drx_sl_unregister_task_giver(simulation_task_33) =drx_sl_reset_stored_task(simulation_task_33)%
 
 
@@ -992,7 +992,7 @@ status_functor = bounty_task
 condlist_0 = {!task_giver_alive(simulation_task_35)} fail
 
 on_job_descr = %=setup_bounty_task(simulation_task_35:false:true:stalker:army:dolg)%
-on_complete = %=reward_random_money(4000:4500) =reward_stash(true) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =complete_task_inc_goodwill(50:bandit) =complete_task_inc_goodwill(-50:stalker) =complete_task_inc_goodwill(-50:csky) =complete_task_inc_goodwill(-50:dolg) =complete_task_inc_goodwill(-50:ecolog) =inc_task_stage(simulation_task_35) =drx_sl_unregister_task_giver(simulation_task_35) =drx_sl_reset_stored_task(simulation_task_35)%
+on_complete = %=reward_random_money(4000:4500) =reward_stash(true) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =complete_task_inc_goodwill(50:bandit) =complete_task_dec_goodwill(50:stalker) =complete_task_dec_goodwill(50:csky) =complete_task_dec_goodwill(50:dolg) =complete_task_dec_goodwill(50:ecolog) =inc_task_stage(simulation_task_35) =drx_sl_unregister_task_giver(simulation_task_35) =drx_sl_reset_stored_task(simulation_task_35)%
 on_fail = %=fail_task_dec_goodwill(50:bandit) =drx_sl_unregister_task_giver(simulation_task_35) =drx_sl_reset_stored_task(simulation_task_35)%
 
 
@@ -1046,7 +1046,7 @@ status_functor_params = killer
 condlist_0 = {!task_giver_alive(simulation_task_37)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_37)%
-on_complete = %=reward_random_money(7000:7500) =complete_task_inc_goodwill(50:killer) =complete_task_inc_goodwill(-50:stalker) =complete_task_inc_goodwill(-50:dolg) =inc_task_stage(simulation_task_37) =drx_sl_unregister_task_giver(simulation_task_37) =drx_sl_reset_stored_task(simulation_task_37)%
+on_complete = %=reward_random_money(7000:7500) =complete_task_inc_goodwill(50:killer) =complete_task_dec_goodwill(50:stalker) =complete_task_dec_goodwill(50:dolg) =inc_task_stage(simulation_task_37) =drx_sl_unregister_task_giver(simulation_task_37) =drx_sl_reset_stored_task(simulation_task_37)%
 on_fail = %=fail_task_dec_goodwill(50:killer) =drx_sl_unregister_task_giver(simulation_task_37) =drx_sl_reset_stored_task(simulation_task_37)%
 
 
@@ -1072,7 +1072,7 @@ status_functor_params = ecolog
 condlist_0 = {!task_giver_alive(simulation_task_38)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_38)%
-on_complete = %=reward_random_money(7000:7500) =reward_stash(true) =complete_task_inc_goodwill(50:ecolog) =complete_task_inc_goodwill(-50:bandit) =complete_task_inc_goodwill(-50:renegade) =inc_task_stage(simulation_task_38) =drx_sl_unregister_task_giver(simulation_task_38) =drx_sl_reset_stored_task(simulation_task_38)%
+on_complete = %=reward_random_money(7000:7500) =reward_stash(true) =complete_task_inc_goodwill(50:ecolog) =complete_task_dec_goodwill(50:bandit) =complete_task_dec_goodwill(50:renegade) =inc_task_stage(simulation_task_38) =drx_sl_unregister_task_giver(simulation_task_38) =drx_sl_reset_stored_task(simulation_task_38)%
 on_fail = %=fail_task_dec_goodwill(50:ecolog) =drx_sl_unregister_task_giver(simulation_task_38) =drx_sl_reset_stored_task(simulation_task_38)%
 
 
@@ -1098,7 +1098,7 @@ status_functor_params = monolith
 condlist_0 = {!task_giver_alive(simulation_task_39)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_39)%
-on_complete = %=reward_random_money(7000:7500) =reward_random_item(charcoal:kerosene__3:batteries_dead:gun_oil:gun_oil_ru_d:sharpening_stones:glue_b:glue_a) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_inc_goodwill(-50:dolg) =inc_task_stage(simulation_task_39) =drx_sl_unregister_task_giver(simulation_task_39) =drx_sl_reset_stored_task(simulation_task_39)%
+on_complete = %=reward_random_money(7000:7500) =reward_random_item(charcoal:kerosene__3:batteries_dead:gun_oil:gun_oil_ru_d:sharpening_stones:glue_b:glue_a) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_dec_goodwill(50:dolg) =inc_task_stage(simulation_task_39) =drx_sl_unregister_task_giver(simulation_task_39) =drx_sl_reset_stored_task(simulation_task_39)%
 on_fail = %=fail_task_dec_goodwill(50:freedom) =drx_sl_unregister_task_giver(simulation_task_39) =drx_sl_reset_stored_task(simulation_task_39)%
 
 
@@ -1124,7 +1124,7 @@ status_functor_params = bandit
 condlist_0 = {!task_giver_alive(simulation_task_40)} fail
 
 on_job_descr = %=setup_assault_task(simulation_task_40)%
-on_complete = %=reward_random_money(5500:6500) =reward_random_item(stimpack:medkit:morphine:drug_booster:tetanus) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_inc_goodwill(-50:freedom) =complete_task_inc_goodwill(-50:killer) =complete_task_inc_goodwill(-50:bandit) =inc_task_stage(simulation_task_40) =drx_sl_unregister_task_giver(simulation_task_40) =drx_sl_reset_stored_task(simulation_task_40)%
+on_complete = %=reward_random_money(5500:6500) =reward_random_item(stimpack:medkit:morphine:drug_booster:tetanus) =reward_random_item(tushonka:protein:beans:chili:nuts:mre:ration_ru:ration_ukr) =reward_random_item(grenade_rgd5:grenade_f1:ammo_m209:mine_new:ied_rpg_new:ied_new) =reward_stash(true) =complete_task_inc_goodwill(50:dolg) =complete_task_dec_goodwill(50:freedom) =complete_task_dec_goodwill(50:killer) =complete_task_dec_goodwill(50:bandit) =inc_task_stage(simulation_task_40) =drx_sl_unregister_task_giver(simulation_task_40) =drx_sl_reset_stored_task(simulation_task_40)%
 on_fail = %=fail_task_dec_goodwill(50:dolg) =drx_sl_unregister_task_giver(simulation_task_40) =drx_sl_reset_stored_task(simulation_task_40)%
 
 
@@ -1549,7 +1549,7 @@ status_functor = bounty_task
 condlist_0 = {!task_giver_alive(simulation_task_56)} fail
 
 on_job_descr = %=setup_bounty_task(simulation_task_56:false:true:stalker:army:dolg:csky)%
-on_complete = %=reward_random_money(5500:6500) =reward_stash(true) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =complete_task_inc_goodwill(50:renegade) =complete_task_inc_goodwill(-50:csky) =complete_task_inc_goodwill(-50:stalker) =complete_task_inc_goodwill(-50:ecolog) =inc_task_stage(simulation_task_56) =drx_sl_unregister_task_giver(simulation_task_56) =drx_sl_reset_stored_task(simulation_task_56)%
+on_complete = %=reward_random_money(5500:6500) =reward_stash(true) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =reward_random_item(beer:vodka:vodka2:cigarettes_lucky:cigarettes_russian) =complete_task_inc_goodwill(50:renegade) =complete_task_dec_goodwill(50:csky) =complete_task_dec_goodwill(50:stalker) =complete_task_dec_goodwill(50:ecolog) =inc_task_stage(simulation_task_56) =drx_sl_unregister_task_giver(simulation_task_56) =drx_sl_reset_stored_task(simulation_task_56)%
 on_fail = %=fail_task_dec_goodwill(50:renegade) =drx_sl_unregister_task_giver(simulation_task_56) =drx_sl_reset_stored_task(simulation_task_56)%
 
 
@@ -1904,7 +1904,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_68)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_68_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_68_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:csky) =complete_task_inc_goodwill(-25:renegade) =complete_task_inc_goodwill(-25:bandit) =inc_task_stage(simulation_task_68) =pstor_reset(simulation_task_68_fetch) =drx_sl_unregister_task_giver(simulation_task_68) =drx_sl_reset_stored_task(simulation_task_68)%
+on_complete = %=fetch_reward_and_remove(simulation_task_68_fetch:2.0) =reward_stash(true) =complete_task_inc_goodwill(50:csky) =complete_task_dec_goodwill(25:renegade) =complete_task_dec_goodwill(25:bandit) =inc_task_stage(simulation_task_68) =pstor_reset(simulation_task_68_fetch) =drx_sl_unregister_task_giver(simulation_task_68) =drx_sl_reset_stored_task(simulation_task_68)%
 on_fail = %=fail_task_dec_goodwill(70:csky) =pstor_reset(simulation_task_68_fetch) =drx_sl_unregister_task_giver(simulation_task_68) =drx_sl_reset_stored_task(simulation_task_68)%
 
 
@@ -1932,7 +1932,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_69)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_69_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_69_fetch:2.6) =reward_stash(true) =complete_task_inc_goodwill(100:ecolog) =complete_task_inc_goodwill(-25:bandit) =complete_task_inc_goodwill(-25:renegade) =inc_task_stage(simulation_task_69) =pstor_reset(simulation_task_69_fetch) =drx_sl_unregister_task_giver(simulation_task_69) =drx_sl_reset_stored_task(simulation_task_69)%
+on_complete = %=fetch_reward_and_remove(simulation_task_69_fetch:2.6) =reward_stash(true) =complete_task_inc_goodwill(100:ecolog) =complete_task_dec_goodwill(25:bandit) =complete_task_dec_goodwill(25:renegade) =inc_task_stage(simulation_task_69) =pstor_reset(simulation_task_69_fetch) =drx_sl_unregister_task_giver(simulation_task_69) =drx_sl_reset_stored_task(simulation_task_69)%
 on_fail = %=fail_task_dec_goodwill(80:ecolog) =pstor_reset(simulation_task_69_fetch) =drx_sl_unregister_task_giver(simulation_task_69) =drx_sl_reset_stored_task(simulation_task_69)%
 
 ;------------------------------------------------
@@ -1959,7 +1959,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_70)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_70_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_70_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_inc_goodwill(-25:dolg) =inc_task_stage(simulation_task_70) =pstor_reset(simulation_task_70_fetch) =drx_sl_unregister_task_giver(simulation_task_70) =drx_sl_reset_stored_task(simulation_task_70)%
+on_complete = %=fetch_reward_and_remove(simulation_task_70_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_dec_goodwill(25:dolg) =inc_task_stage(simulation_task_70) =pstor_reset(simulation_task_70_fetch) =drx_sl_unregister_task_giver(simulation_task_70) =drx_sl_reset_stored_task(simulation_task_70)%
 on_fail = %=fail_task_dec_goodwill(50:freedom) =pstor_reset(simulation_task_70_fetch) =drx_sl_unregister_task_giver(simulation_task_70) =drx_sl_reset_stored_task(simulation_task_70)%
 
 ;------------------------------------------------
@@ -1986,7 +1986,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_71)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_71_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_71_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(50:killer) =complete_task_inc_goodwill(-25:stalker) =complete_task_inc_goodwill(-25:dolg) =inc_task_stage(simulation_task_71) =pstor_reset(simulation_task_71_fetch) =drx_sl_unregister_task_giver(simulation_task_71) =drx_sl_reset_stored_task(simulation_task_71)%
+on_complete = %=fetch_reward_and_remove(simulation_task_71_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(50:killer) =complete_task_dec_goodwill(25:stalker) =complete_task_dec_goodwill(25:dolg) =inc_task_stage(simulation_task_71) =pstor_reset(simulation_task_71_fetch) =drx_sl_unregister_task_giver(simulation_task_71) =drx_sl_reset_stored_task(simulation_task_71)%
 on_fail = %=fail_task_dec_goodwill(45:killer) =pstor_reset(simulation_task_71_fetch) =drx_sl_unregister_task_giver(simulation_task_71) =drx_sl_reset_stored_task(simulation_task_71)%
 
 ;------------------------------------------------
@@ -2013,7 +2013,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_72)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_72_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_72_fetch:1.7) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_inc_goodwill(-25:bandit) =complete_task_inc_goodwill(-25:renegade) =complete_task_inc_goodwill(-25:killer) =inc_task_stage(simulation_task_72) =pstor_reset(simulation_task_72_fetch) =drx_sl_unregister_task_giver(simulation_task_72) =drx_sl_reset_stored_task(simulation_task_72)%
+on_complete = %=fetch_reward_and_remove(simulation_task_72_fetch:1.7) =reward_stash(true) =complete_task_inc_goodwill(50:stalker) =complete_task_dec_goodwill(25:bandit) =complete_task_dec_goodwill(25:renegade) =complete_task_dec_goodwill(25:killer) =inc_task_stage(simulation_task_72) =pstor_reset(simulation_task_72_fetch) =drx_sl_unregister_task_giver(simulation_task_72) =drx_sl_reset_stored_task(simulation_task_72)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =pstor_reset(simulation_task_72_fetch) =drx_sl_unregister_task_giver(simulation_task_72) =drx_sl_reset_stored_task(simulation_task_72)%
 
 
@@ -2041,7 +2041,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_73)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_73_fetch:artefacts:1:1)%
-on_complete = %=fetch_reward_and_remove(simulation_task_73_fetch:1.7) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_inc_goodwill(-25:stalker) =inc_task_stage(simulation_task_73) =pstor_reset(simulation_task_73_fetch) =drx_sl_unregister_task_giver(simulation_task_73) =drx_sl_reset_stored_task(simulation_task_73)%
+on_complete = %=fetch_reward_and_remove(simulation_task_73_fetch:1.7) =reward_stash(true) =complete_task_inc_goodwill(50:army) =complete_task_dec_goodwill(25:stalker) =inc_task_stage(simulation_task_73) =pstor_reset(simulation_task_73_fetch) =drx_sl_unregister_task_giver(simulation_task_73) =drx_sl_reset_stored_task(simulation_task_73)%
 on_fail = %=fail_task_dec_goodwill(50:army) =pstor_reset(simulation_task_73_fetch) =drx_sl_unregister_task_giver(simulation_task_73) =drx_sl_reset_stored_task(simulation_task_73)%
 
 
@@ -2263,7 +2263,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_81)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_81_fetch:mutant_meat_rare_x:1:2)%
-on_complete = %=fetch_reward_and_remove(simulation_task_81_fetch:2.2) =reward_stash(true) =complete_task_inc_goodwill(10:ecolog) =complete_task_inc_goodwill(-10:bandit) =complete_task_inc_goodwill(-10:renegade) =inc_task_stage(simulation_task_81) =pstor_reset(simulation_task_81_fetch) =drx_sl_unregister_task_giver(simulation_task_81) =drx_sl_reset_stored_task(simulation_task_81)%
+on_complete = %=fetch_reward_and_remove(simulation_task_81_fetch:2.2) =reward_stash(true) =complete_task_inc_goodwill(10:ecolog) =complete_task_dec_goodwill(10:bandit) =complete_task_dec_goodwill(10:renegade) =inc_task_stage(simulation_task_81) =pstor_reset(simulation_task_81_fetch) =drx_sl_unregister_task_giver(simulation_task_81) =drx_sl_reset_stored_task(simulation_task_81)%
 on_fail = %=fail_task_dec_goodwill(25:ecolog) =pstor_reset(simulation_task_81_fetch) =drx_sl_unregister_task_giver(simulation_task_81) =drx_sl_reset_stored_task(simulation_task_81)%
 
 ;------------------------------------------------
@@ -2290,7 +2290,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_82)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_82_fetch:mutant_meat_rare_x:1:2)%
-on_complete = %=fetch_reward_and_remove(simulation_task_82_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(10:dolg) =complete_task_inc_goodwill(-10:freedom) =complete_task_inc_goodwill(-10:killer) =complete_task_inc_goodwill(-10:bandit) =inc_task_stage(simulation_task_82) =pstor_reset(simulation_task_82_fetch) =drx_sl_unregister_task_giver(simulation_task_82) =drx_sl_reset_stored_task(simulation_task_82)%
+on_complete = %=fetch_reward_and_remove(simulation_task_82_fetch:1.8) =reward_stash(true) =complete_task_inc_goodwill(10:dolg) =complete_task_dec_goodwill(10:freedom) =complete_task_dec_goodwill(10:killer) =complete_task_dec_goodwill(10:bandit) =inc_task_stage(simulation_task_82) =pstor_reset(simulation_task_82_fetch) =drx_sl_unregister_task_giver(simulation_task_82) =drx_sl_reset_stored_task(simulation_task_82)%
 on_fail = %=fail_task_dec_goodwill(20:dolg) =pstor_reset(simulation_task_82_fetch) =drx_sl_unregister_task_giver(simulation_task_82) =drx_sl_reset_stored_task(simulation_task_82)%
 
 
@@ -2825,7 +2825,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_101)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_101_fetch:medical_x:2:5)%
-on_complete = %=fetch_reward_and_remove(simulation_task_101_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(12:stalker) =complete_task_inc_goodwill(-5:bandit) =complete_task_inc_goodwill(-5:renegade) =complete_task_inc_goodwill(-12:killer) =inc_task_stage(simulation_task_101) =pstor_reset(simulation_task_101_fetch) =drx_sl_unregister_task_giver(simulation_task_101) =drx_sl_reset_stored_task(simulation_task_101)%
+on_complete = %=fetch_reward_and_remove(simulation_task_101_fetch:0.8) =reward_stash(true) =complete_task_inc_goodwill(12:stalker) =complete_task_dec_goodwill(5:bandit) =complete_task_dec_goodwill(5:renegade) =complete_task_dec_goodwill(12:killer) =inc_task_stage(simulation_task_101) =pstor_reset(simulation_task_101_fetch) =drx_sl_unregister_task_giver(simulation_task_101) =drx_sl_reset_stored_task(simulation_task_101)%
 on_fail = %=fail_task_dec_goodwill(50:stalker) =pstor_reset(simulation_task_101_fetch) =drx_sl_unregister_task_giver(simulation_task_101) =drx_sl_reset_stored_task(simulation_task_101)%
 
 ;------------------------------------------------
@@ -2852,7 +2852,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_102)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_102_fetch:medical_x:2:5)%
-on_complete = %=fetch_reward_and_remove(simulation_task_102_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(15:csky) =complete_task_inc_goodwill(-5:renegade) =complete_task_inc_goodwill(-5:bandit) =inc_task_stage(simulation_task_102) =pstor_reset(simulation_task_102_fetch) =drx_sl_unregister_task_giver(simulation_task_102) =drx_sl_reset_stored_task(simulation_task_102)%
+on_complete = %=fetch_reward_and_remove(simulation_task_102_fetch:0.7) =reward_stash(true) =complete_task_inc_goodwill(15:csky) =complete_task_dec_goodwill(5:renegade) =complete_task_dec_goodwill(5:bandit) =inc_task_stage(simulation_task_102) =pstor_reset(simulation_task_102_fetch) =drx_sl_unregister_task_giver(simulation_task_102) =drx_sl_reset_stored_task(simulation_task_102)%
 on_fail = %=fail_task_dec_goodwill(30:csky) =pstor_reset(simulation_task_102_fetch) =drx_sl_unregister_task_giver(simulation_task_102) =drx_sl_reset_stored_task(simulation_task_102)%
 
 ;------------------------------------------------
@@ -2879,7 +2879,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_103)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_103_fetch:medical_x:2:5)%
-on_complete = %=fetch_reward_and_remove(simulation_task_103_fetch:1.2) =reward_stash(true) =complete_task_inc_goodwill(20:freedom) =complete_task_inc_goodwill(-5:dolg)  =inc_task_stage(simulation_task_103) =pstor_reset(simulation_task_103_fetch) =drx_sl_unregister_task_giver(simulation_task_103) =drx_sl_reset_stored_task(simulation_task_103)%
+on_complete = %=fetch_reward_and_remove(simulation_task_103_fetch:1.2) =reward_stash(true) =complete_task_inc_goodwill(20:freedom) =complete_task_dec_goodwill(5:dolg)  =inc_task_stage(simulation_task_103) =pstor_reset(simulation_task_103_fetch) =drx_sl_unregister_task_giver(simulation_task_103) =drx_sl_reset_stored_task(simulation_task_103)%
 on_fail = %=fail_task_dec_goodwill(40:freedom) =pstor_reset(simulation_task_103_fetch) =drx_sl_unregister_task_giver(simulation_task_103) =drx_sl_reset_stored_task(simulation_task_103)%
 
 ;------------------------------------------------
@@ -3401,7 +3401,7 @@ status_functor = actor_has_fetch_item
 condlist_0 = {!task_giver_alive(simulation_task_122)} fail
 
 fetch_func = %=setup_fetch_task(simulation_task_122_fetch:freedom_drugs:1:4)%
-on_complete = %=fetch_reward_and_remove(simulation_task_122_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_inc_goodwill(-50:dolg) =inc_task_stage(simulation_task_122) =pstor_reset(simulation_task_122_fetch) =drx_sl_unregister_task_giver(simulation_task_122) =drx_sl_reset_stored_task(simulation_task_122)%
+on_complete = %=fetch_reward_and_remove(simulation_task_122_fetch:0.9) =reward_stash(true) =complete_task_inc_goodwill(50:freedom) =complete_task_dec_goodwill(50:dolg) =inc_task_stage(simulation_task_122) =pstor_reset(simulation_task_122_fetch) =drx_sl_unregister_task_giver(simulation_task_122) =drx_sl_reset_stored_task(simulation_task_122)%
 on_fail = %=fail_task_dec_goodwill(50:csky) =pstor_reset(simulation_task_122_fetch) =drx_sl_unregister_task_giver(simulation_task_122) =drx_sl_reset_stored_task(simulation_task_122)%
 
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/scripts/xr_effects.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Quests Rebalance/gamedata/scripts/xr_effects.script
@@ -1298,6 +1298,16 @@ function complete_task_inc_goodwill(actor,npc,p)
 	end
 end
 
+function complete_task_dec_goodwill(actor,npc,p)
+-- param1 - amount of goodwill to decrease
+-- param2+ - community
+	local multi = game_difficulties.get_eco_factor("goodwill") or 1
+	local amt = tonumber(p[1])*multi or 50
+	for i=2,#p do
+		inc_faction_goodwill_to_actor(db.actor, nil, {p[i], -amt, true})
+	end
+end
+
 function inc_goodwill_by_tasker_comm(actor,npc,p)
 -- param1 - task_id
 -- param2 - amount of goodwill to increase


### PR DESCRIPTION
It turns out you can't put negative numbers into task rewards because the minus sign breaks the parser
You can, however, use a function that reduces goodwill while taking a positive number
This PR makes goodwill loss work as (probably) intended
<img width="939" height="437" alt="image" src="https://github.com/user-attachments/assets/dd46a211-95f5-4b87-8b10-c2033d80b028" />
