### PR TITLE
revert Press Key To Drop Item fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Press Key to Drop Item/gamedata/scripts/grok_drop_item_press_key_mcm.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Press Key to Drop Item/gamedata/scripts/grok_drop_item_press_key_mcm.script
@@ -55,7 +55,7 @@ local function on_key_press(key)
 						end
 					end
 				end
-			if obj_to_drop and obj_to_drop:parent() and obj_to_drop:parent():id() == AC_ID then
+			if obj_to_drop then
 				db.actor:drop_item(obj_to_drop)
 				snd:play(db.actor,0,sound_object.s2d)
 				itms_manager.play_item_sound(obj_to_drop)


### PR DESCRIPTION
Apparently parent check doesn't seem to fix much while causing "access class" errors that makes game unplayable.
Dropping glowsticks can be blocked as a bandaid, but the error it causes seems harmless.