### PR TITLE
arti_jamming:475 crash fix

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/momopate_proper_jam_chance.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/momopate_proper_jam_chance.script
@@ -15,10 +15,7 @@ if zzzz_arti_jamming_repairs and zzzz_arti_jamming_repairs.process_jam_chance th
 			if arti_jamming.get_jam_chance then
 				if wpn then 
 					jam_prob = arti_jamming.get_jam_chance(wpn)
-					-- oleh5230
-					silencer_jam_chance = arti_jamming.get_silencer_jam_chance and arti_jamming.get_silencer_jam_chance(wpn) * 0.1 or 0
-					-- oleh5230 end
-					
+
 					-- momopate: calc the in-engine's jam chance. not all of this shit is accessible via traditional methods so it needs to be this ugly.
 					start_prob = SYS_GetParam(2, wpn:section(), "misfire_start_prob") or 0
 					start_cond = SYS_GetParam(2, wpn:section(), "misfire_start_condition") or 0
@@ -48,6 +45,12 @@ if zzzz_arti_jamming_repairs and zzzz_arti_jamming_repairs.process_jam_chance th
 						-- that's the vanilla jam chance formula, straight from the source code
 						vanilla_jam_chance = clamp(start_prob + ((start_cond - wpn:condition()) * (end_prob - start_prob) / divisor), 0, 0.99)
 					end
+
+					-- oleh5230
+					silencer_status = wpn:weapon_is_silencer() and 1 or SYS_GetParam(2, wpn:section(), "silencer_status", 0) == 1 and 1 or 0
+					silencer_jam_chance = start_prob < 0.002 and 1 * silencer_status or start_prob * 330 * silencer_status
+					silencer_jam_chance = silencer_jam_chance * 0.1
+					-- oleh5230 end
 
 					vanilla_jam_chance = vanilla_jam_chance * 100
 					total_jam_prob = jam_prob + vanilla_jam_chance + silencer_jam_chance


### PR DESCRIPTION
Fix for recently merged weapon degradation changes.
Calculates jam chance locally since arti_jamming stores jam parameters only for active item.