### PR TITLE
Fix for weapon section identification in grok_bo.script

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/grok_bo.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/scripts/grok_bo.script
@@ -561,8 +561,9 @@ function npc_on_before_hit(npc,shit,bone_id)
 	else
 		silencer_boost = 1
 	end
-	
-	if sec and integrated_silencer[sec] then
+
+	local parent_section = ini_sys:r_string_ex(wpn:section(), "parent_section") or wpn:section()
+	if parent_section and integrated_silencer[parent_section] then
 		silencer_boost = 1.07
 	end
 
@@ -865,8 +866,9 @@ function npc_on_before_hit(npc,shit,bone_id)
 			k_ap = ( k_ap + 0.040 )
 		end
 	end
-	
-	if snipers[wpn:section()] then
+
+	local parent_section = ini_sys:r_string_ex(wpn:section(), "parent_section") or wpn:section()
+	if snipers[parent_section] then
 		k_ap = k_ap + 0.05
 	end
 


### PR DESCRIPTION
Fix for the incorrect wpn section being used to check a look up table of weapon section and instead correctly uses parent_section