### PR TITLE
RF/delivery package loot rework

### DIFF
--- a/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/configs/items/settings/mod_itms_manager_package_loot_oleh.ltx
+++ b/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/configs/items/settings/mod_itms_manager_package_loot_oleh.ltx
@@ -1,20 +1,20 @@
 ![package_content]
-quest_package_1		= ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj,ammo_pkm_100
+quest_package_1		= ammo_5.7x28_ss195,ammo_9x18_fmj,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_5.45x39_fmj,ammo_5.56x45_fmj,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_pkm_100
 quest_package_2     = sewing_thread,sewing_thread,heavy_sewing_thread,armor_repair_fa,glue_b,glue_a,glue_e,sewing_kit_b,sewing_kit_a,sewing_kit_h
 quest_package_3     = rasp_tool,ramrod_tool,gun_oil_ru,gun_oil_ru_d,gun_oil,gun_oil,solvent,cleaning_kit_s,cleaning_kit_r5,cleaning_kit_r7
 quest_package_4     = cigarettes,cigarettes_lucky,jgut,cigar,stimpack,medkit_army,drug_radioprotector,drug_coagulant,akvatab,drug_antidot,antirad,adrenalin,rebirth
 quest_package_5     = cigarettes,cigarettes_lucky,jgut,cigar,stimpack,medkit_army,drug_radioprotector,drug_coagulant,akvatab,drug_antidot,antirad,adrenalin,rebirth
-quest_package_6     = ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj,ammo_pkm_100
-quest_package_7     = bullet_pistol,bullet_pistol_ap,bullet_shotgun,bullet_shotgun_ap,bullet_r5,bullet_r5_ap,bullet_r7,bullet_r7_ap,casing_p,casing_s,casing_r5,casing_r7,powder_1,powder_2,powder_3,bullet_pistol,bullet_pistol_ap,bullet_shotgun,bullet_shotgun_ap,bullet_r5,bullet_r5_ap,bullet_r7,bullet_r7_ap,casing_p,casing_s,casing_r5,casing_r7,powder_1,powder_2,powder_3
+quest_package_6     = ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj
+quest_package_7     = ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj
 quest_package_8     = ammo_12x76_dart,ammo_5.45x39_ap,ammo_5.56x45_ap,ammo_9x39_ap,ammo_7.62x39_ap,ammo_7.62x51_ap,ammo_7.92x33_ap,ammo_338_federal,ammo_12.7x55_ap,ammo_7.62x54_ap,ammo_vog-25,ammo_m209
 
 @[package_settings]
-; example_package   = <minimal item quantity> (default: 4),<maximum item quantity> (default: 6),<pick chance> (default: 50),<table shuffle flag> (default: false)
-quest_package_1		= 12,16,50,true
-quest_package_2     = 4,6,50,false
-quest_package_3     = 4,6,50,false
-quest_package_4     = 4,6,50,false
-quest_package_5     = 4,6,50,false
-quest_package_6     = 12,16,50,true
-quest_package_7     = 12,16,50,true
-quest_package_8     = 4,6,50,true
+; example_package   = <minimal item quantity> (default: 4), <maximum item quantity> (default: 6), <pick chance> (default: 50), <type> ("ammo": selects one entry randomly and and spawns it multiple time)
+quest_package_1		= 12,16,50,ammo ; big ammo crate, base ammo types only
+quest_package_2     = 4,6,50        ; armor repair 
+quest_package_3     = 4,6,50        ; weapon repair
+quest_package_4     = 4,6,50        ; consumables
+quest_package_5     = 4,6,50        ; consumables
+quest_package_6     = 6,8,50,ammo   ; medium ammo box, all ammo types except most expensive
+quest_package_7     = 6,8,50,ammo   ; medium ammo box, all ammo types except most expensive
+quest_package_8     = 4,6,50,ammo   ; small ammo box, expensive ammo types only

--- a/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/configs/items/settings/mod_itms_manager_package_loot_oleh.ltx
+++ b/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/configs/items/settings/mod_itms_manager_package_loot_oleh.ltx
@@ -1,0 +1,20 @@
+![package_content]
+quest_package_1		= ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj,ammo_pkm_100
+quest_package_2     = sewing_thread,sewing_thread,heavy_sewing_thread,armor_repair_fa,glue_b,glue_a,glue_e,sewing_kit_b,sewing_kit_a,sewing_kit_h
+quest_package_3     = rasp_tool,ramrod_tool,gun_oil_ru,gun_oil_ru_d,gun_oil,gun_oil,solvent,cleaning_kit_s,cleaning_kit_r5,cleaning_kit_r7
+quest_package_4     = cigarettes,cigarettes_lucky,jgut,cigar,stimpack,medkit_army,drug_radioprotector,drug_coagulant,akvatab,drug_antidot,antirad,adrenalin,rebirth
+quest_package_5     = cigarettes,cigarettes_lucky,jgut,cigar,stimpack,medkit_army,drug_radioprotector,drug_coagulant,akvatab,drug_antidot,antirad,adrenalin,rebirth
+quest_package_6     = ammo_5.7x28_ss190,ammo_9x18_ap,ammo_9x19_ap,ammo_9x18_fmj,ammo_9x18_pmm,ammo_9x19_pbp,ammo_9x19_fmj,ammo_9x21_sp10,ammo_11.43x23_hydro,ammo_11.43x23_fmj,ammo_20x70_buck,ammo_12x70_buck,ammo_12x76_zhekan,ammo_357_hp_mag,ammo_5.45x39_fmj,ammo_5.45x39_ep,ammo_5.56x45_fmj,ammo_5.56x45_ss190,ammo_5.7x28_ss195,ammo_9x39_pab9,ammo_7.62x39_fmj,ammo_7.62x51_fmj,ammo_7.62x25_p,ammo_7.62x25_ps,ammo_7.92x33_fmj,ammo_7.62x54_7h1,ammo_7.62x54_7h14,ammo_12.7x55_fmj,ammo_pkm_100
+quest_package_7     = bullet_pistol,bullet_pistol_ap,bullet_shotgun,bullet_shotgun_ap,bullet_r5,bullet_r5_ap,bullet_r7,bullet_r7_ap,casing_p,casing_s,casing_r5,casing_r7,powder_1,powder_2,powder_3,bullet_pistol,bullet_pistol_ap,bullet_shotgun,bullet_shotgun_ap,bullet_r5,bullet_r5_ap,bullet_r7,bullet_r7_ap,casing_p,casing_s,casing_r5,casing_r7,powder_1,powder_2,powder_3
+quest_package_8     = ammo_12x76_dart,ammo_5.45x39_ap,ammo_5.56x45_ap,ammo_9x39_ap,ammo_7.62x39_ap,ammo_7.62x51_ap,ammo_7.92x33_ap,ammo_338_federal,ammo_12.7x55_ap,ammo_7.62x54_ap,ammo_vog-25,ammo_m209
+
+@[package_settings]
+; example_package   = <minimal item quantity> (default: 4),<maximum item quantity> (default: 6),<pick chance> (default: 50),<table shuffle flag> (default: false)
+quest_package_1		= 12,16,50,true
+quest_package_2     = 4,6,50,false
+quest_package_3     = 4,6,50,false
+quest_package_4     = 4,6,50,false
+quest_package_5     = 4,6,50,false
+quest_package_6     = 12,16,50,true
+quest_package_7     = 12,16,50,true
+quest_package_8     = 4,6,50,true

--- a/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/scripts/z_itms_manager_package_loot_oleh.script
+++ b/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/scripts/z_itms_manager_package_loot_oleh.script
@@ -16,44 +16,49 @@ function itms_manager.use_package_random(obj)
 	local min_items 	= tonumber(ts[1]) or 4
 	local max_items 	= tonumber(ts[2]) or 6
 	local chance		= tonumber(ts[3]) or 50
-	local shuffle_flag	= ts[4] or false
-	if shuffle_flag then shuffle_table(t) end
-	printf("[use_package_random] %s min: %s max: %s chance: %s shuffle: %s", sec, min_items, max_items, chance, shuffle_flag)
+	local type			= ts[4]
+	printf("[use_package_random] %s min: %s max: %s chance: %s type: %s", sec, min_items, max_items, chance, type)
 
 	local pick = {}
-	for i=1,#t do
-		if (#pick < max_items) and (math.random(100) < chance) then
-			pick[#pick+1] = t[i]
+	if type and type == "ammo" then
+		local ammo_type = t[math.random(#t)]
+		local ammo_amount = pistol_ammo[ammo_type] and max_items or min_items
+		for i=1,ammo_amount do
+			pick[#pick+1] = ammo_type
 		end
-	end
+	else
+		for i=1,#t do
+			if (#pick < max_items) and (math.random(100) < chance) then
+				pick[#pick+1] = t[i]
+			end
+		end
 
-	-- if too few picks, fill with random items until minimum threshold is reached
-	if #pick < min_items then
-		printf("[use_package_random] not enough items, backup fill")
-		for i=#pick, min_items do
-			table.insert(pick, t[math.random(#t)])
+		-- if too few picks, fill with random items until minimum threshold is reached
+		if #pick < min_items then
+			printf("[use_package_random] not enough items, backup fill")
+			for i = #pick + 1, min_items do
+				table.insert(pick, t[math.random(#t)])
+			end
 		end
 	end
+	pick = #pick > 1 and pick or {"money_5000"}
 
 	utils_item.delay_event(pick, {obj:id()}, "package_content", true, 5)
 end
 
-ammo_package = {
-	["quest_package_1"] = true,
-	["quest_package_6"] = true,
-	["quest_package_7"] = true,
-	["quest_package_8"] = true,
-	["quest_tb_package_1"] = true,
-	["quest_tb_package_6"] = true,
-	["quest_tb_package_7"] = true,
-	["quest_tb_package_8"] = true,
-}
-
-big_ammo_package = {
-	["quest_package_1"] = true,
-	["quest_package_6"] = true,
-	["quest_package_7"] = true,
-	["quest_tb_package_1"] = true,
-	["quest_tb_package_6"] = true,
-	["quest_tb_package_7"] = true,
+pistol_ammo = {
+	["ammo_9x18_ap"] = true,
+	["ammo_9x18_fmj"] = true,
+	["ammo_9x18_pmm"] = true,
+	["ammo_9x19_ap"] = true,
+	["ammo_9x19_fmj"] = true,
+	["ammo_9x19_pbp"] = true,
+	["ammo_11.43x23_fmj"] = true,
+	["ammo_11.43x23_hydro"] = true,
+	["ammo_5.7x28_ss195"] = true,
+	["ammo_5.7x28_ss190"] = true,
+	["ammo_7.62x25_p"] = true,
+	["ammo_7.62x25_ps"] = true,
+	["ammo_357_hp_mag"] = true,
+	["ammo_9x21_sp10"] = true,
 }

--- a/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/scripts/z_itms_manager_package_loot_oleh.script
+++ b/G.A.M.M.A/modpack_addons/Oleh's Package Loot Rework/gamedata/scripts/z_itms_manager_package_loot_oleh.script
@@ -1,0 +1,59 @@
+-- Prepare ini files
+ini_manager = ini_manager or ini_file("items\\settings\\itms_manager.ltx")
+
+use_package_random = itms_manager.use_package_random
+function itms_manager.use_package_random(obj)
+	local sec = obj:section()
+	local content = ini_manager:r_string_ex("package_content",sec)
+	if not content then return end
+	local t = str_explode(content,",")
+
+	local settings = ini_manager:r_string_ex("package_settings",sec)
+	local ts = {}
+	if settings then
+		ts = str_explode(settings,",")
+	end
+	local min_items 	= tonumber(ts[1]) or 4
+	local max_items 	= tonumber(ts[2]) or 6
+	local chance		= tonumber(ts[3]) or 50
+	local shuffle_flag	= ts[4] or false
+	if shuffle_flag then shuffle_table(t) end
+	printf("[use_package_random] %s min: %s max: %s chance: %s shuffle: %s", sec, min_items, max_items, chance, shuffle_flag)
+
+	local pick = {}
+	for i=1,#t do
+		if (#pick < max_items) and (math.random(100) < chance) then
+			pick[#pick+1] = t[i]
+		end
+	end
+
+	-- if too few picks, fill with random items until minimum threshold is reached
+	if #pick < min_items then
+		printf("[use_package_random] not enough items, backup fill")
+		for i=#pick, min_items do
+			table.insert(pick, t[math.random(#t)])
+		end
+	end
+
+	utils_item.delay_event(pick, {obj:id()}, "package_content", true, 5)
+end
+
+ammo_package = {
+	["quest_package_1"] = true,
+	["quest_package_6"] = true,
+	["quest_package_7"] = true,
+	["quest_package_8"] = true,
+	["quest_tb_package_1"] = true,
+	["quest_tb_package_6"] = true,
+	["quest_tb_package_7"] = true,
+	["quest_tb_package_8"] = true,
+}
+
+big_ammo_package = {
+	["quest_package_1"] = true,
+	["quest_package_6"] = true,
+	["quest_package_7"] = true,
+	["quest_tb_package_1"] = true,
+	["quest_tb_package_6"] = true,
+	["quest_tb_package_7"] = true,
+}

--- a/G.A.M.M.A/modpack_data/modlist.txt
+++ b/G.A.M.M.A/modpack_data/modlist.txt
@@ -75,6 +75,7 @@
 -307- French Rework Improved Translation & Enhanced Style - Thundard
 -377- GAMMA Portugues Brasileiro Traducao - PedroAmaral89
 +Oleh's Tasks Crash Fixes
++Oleh's Package Loot Rework
 +Scrunkly's Collection of Mods
 +478- Custom iTheon's PDA Taskboard - lizzardman
 +463- Tasks QoL Pack - Serious


### PR DESCRIPTION
Not really a rework since there's no much time left until patch release, main change is ammo packages are not worthless (6-12 ammo boxes instead of 2-6 (doesn't apply to AP ammo, those are still rare)).

Update: ammo packages now drop ammo of single type, less bloat and easier to balance.