### PR TITLE
Stalker loot tweaks

### DIFF
--- a/G.A.M.M.A/modpack_addons/437- Weighted NPC Random Loadouts - SD/gamedata/configs/items/settings/npc_loadouts/npc_loadouts.ltx
+++ b/G.A.M.M.A/modpack_addons/437- Weighted NPC Random Loadouts - SD/gamedata/configs/items/settings/npc_loadouts/npc_loadouts.ltx
@@ -129,12 +129,18 @@ grenade_rgd5:0:1:2
 		
 	bar_dolg_leader                                        = dolg
 	bar_dolg_general_petrenko_stalker                      = dolg
+	bar_dolg_general_zoneguard_stalker					   = dolg
 	bar_visitors_stalker_mechanic                          = dolg
 	bar_dolg_medic                                         = dolg
+	bar_zastava_2_commander								   = dolg
+	bar_duty_security_squad_leader						   = dolg
 		
 	yan_ecolog_kruglov                                     = ecolog
 	yan_stalker_sakharov                                   = ecolog
 	yan_povar_army_mlr                                     = ecolog
+	yan_merc_01			                                   = ecolog
+	yan_merc_02			                                   = ecolog
+	yan_merc_03			                                   = ecolog
 	mechanic_army_yan_mlr                                  = ecolog
 	jup_b6_scientist_tech                                  = ecolog
 	jup_b6_scientist_nuclear_physicist                     = ecolog
@@ -205,6 +211,11 @@ grenade_rgd5:0:1:2
 	trader_pri_a15_mlr                                     = stalker
 	guid_jup_stalker_garik                                 = stalker
 	zat_tech_mlr                                           = stalker
+	bar_arena_manager									   = stalker
+	bar_arena_guard										   = stalker
+	bar_arena_savage									   = stalker
+	bar_visitors_garik_stalker_guard					   = stalker
+	bar_visitors_zhorik_stalker_guard2				   	   = stalker
 		
 	kat_greh_sabaoth                                       = greh
 	red_greh_trader                                        = greh

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy (don't disable, turn on Black Market to buy gear)/gamedata/scripts/death_manager.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy (don't disable, turn on Black Market to buy gear)/gamedata/scripts/death_manager.script
@@ -481,6 +481,34 @@ function keep_item(npc, item) -- The function is called for each item, and decid
 			return
 		end
 	end
+
+	-- oleh5230
+	-- Release delivery packages
+	if string.find(section,"quest_package") then
+		alife_release(se_item)
+		return
+	end
+
+	-- GAMMA stuff
+	if section == "detector_advanced" or section == "detector_elite" or section == "detector_scientific" then
+		alife_release(se_item)
+		return
+	end
+	
+	if IsOutfit(nil,cls) and string.find(section,"nosorog") then
+		if math.random(100) > 15 then
+			alife_release(se_item)
+			return
+		end
+	end
+	
+	if section == "helm_spartan" then
+		if math.random(100) > 50 then
+			alife_release(se_item)
+			return
+		end
+	end
+	--oleh5230 end
 	
 	--[[
 	local temp = not (death_ini:line_exist("exclude_from_multi",section)) and diff_multi or 1

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy (don't disable, turn on Black Market to buy gear)/gamedata/scripts/death_manager.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Economy (don't disable, turn on Black Market to buy gear)/gamedata/scripts/death_manager.script
@@ -380,7 +380,7 @@ end
 
 function keep_item(npc, item) -- The function is called for each item, and decide if this item should stay or get released.
 	if not (item) then
-		return 
+		return
 	end 
 	
 	-- Keep whitelisted items from death manager
@@ -388,7 +388,7 @@ function keep_item(npc, item) -- The function is called for each item, and decid
 	local item_id = item:id()
 	
 	if (always_keep_item[section]) then 
-		return 
+		return
 	end 
 	
 	
@@ -483,30 +483,15 @@ function keep_item(npc, item) -- The function is called for each item, and decid
 	end
 
 	-- oleh5230
-	-- Release delivery packages
+	-- Release delivery packages and detectors
 	if string.find(section,"quest_package") then
 		alife_release(se_item)
 		return
 	end
 
-	-- GAMMA stuff
 	if section == "detector_advanced" or section == "detector_elite" or section == "detector_scientific" then
 		alife_release(se_item)
 		return
-	end
-	
-	if IsOutfit(nil,cls) and string.find(section,"nosorog") then
-		if math.random(100) > 15 then
-			alife_release(se_item)
-			return
-		end
-	end
-	
-	if section == "helm_spartan" then
-		if math.random(100) > 50 then
-			alife_release(se_item)
-			return
-		end
 	end
 	--oleh5230 end
 	
@@ -528,7 +513,6 @@ function keep_item(npc, item) -- The function is called for each item, and decid
 	
 	--alife_release(se_item)
 end
-
 
 -------------------------------
 -- WEAPONS
@@ -848,8 +832,34 @@ function get_condition_by_rank(rank,coef)
 	return con
 end
 
+rare_armors = {
+	["army_nosorog_outfit"] = true,	       
+	["freedom_nosorog_outfit"] = true,	       
+	["isg_nosorog_outfit"] = true,	  
+	["merc_nosorog_outfit"] = true,	     
+	["monolith_nosorog_outfit"] = true,	 
+	["dolg_nosorog_outfit"] = true,		
+}
+
 function validate_drop(section)
 	local outfit_drop_mode = game_difficulties.get_eco_factor("outfit_drops") or 2
+
+	-- oleh5230 
+	-- GAMMA stuff
+	if rare_armors[section] then
+		if math.random(100) > 15 then
+			--printf("[death_manager] nosorog despawned")
+			return false
+		end
+	end
+	
+	if section == "helm_spartan" then
+		if math.random(100) > 50 then
+			--printf("[death_manager] spartan helm despawned")
+			return false
+		end
+	end
+	-- oleh5230 end
 	
 	-- Progressive.  Drop outfits and helmets according to player rank
 	if (outfit_drop_mode == 2) then 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Skill System Balance/gamedata/scripts/haru_skills.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Skill System Balance/gamedata/scripts/haru_skills.script
@@ -358,25 +358,7 @@ function scavanger_effect(npc)
 				print_dbg("Releasing [%s]", item:section())
 				--alife_release(item)
 			end
-
-		if item:section() == "detector_elite" or item:section() == "detector_scientific" then
-			alife_release(item)
 		end
-		
-		if rare_armors[item:section()] then
-			armor_spawn_chance = math.random(1,100)
-			if armor_spawn_chance > 15 then
-				alife_release(item)
-			end
-		end
-		
-		if item:section() == "helm_spartan" then
-			helm_spawn_chance = math.random(1,100)
-			if helm_spawn_chance > 50 then
-				alife_release(item)
-			end
-		end
-    end
     npc:iterate_inventory(itr, npc)
 end
 


### PR DESCRIPTION
- Despawn delivery packages (to prevent opening packages without task failure penalties)
- Move despawn logic from skill system to death manager (for custom modlist users + no latency)
- Blacklist some story NPCs from loadout script (currently they drop 4 weapons)