### PR TITLE
Replace 'copper' with 'prt_i_copper' in recipes

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Artefacts Reinvention/gamedata/configs/items/settings/craft.ltx
@@ -99,8 +99,8 @@ x_af_cooler				            = 2, recipe_basic_1, prt_o_retardant_7,4,prt_i_scrap,
 x_af_camelbak				        = 2, recipe_basic_1, prt_i_scrap,5,prt_o_ballistic_9,4,prt_o_ballistic_13,3,prt_o_retardant_13,3
 x_af_frames_up			            = 2, recipe_advanced_1, af_frames,1,prt_o_ballistic_16,12,prt_i_fasteners,12,prt_i_scrap,12
 x_af_grid_up   			            = 2, recipe_advanced_1, af_grid,1,prt_o_ballistic_6,4,prt_i_fasteners,4,prt_o_fabrics_4,4
-x_af_cooler_up  			        = 2, recipe_advanced_1, af_cooler,1,prt_o_retardant_8,8,prt_o_retardant_17,8,copper,8
-x_af_freon_up				        = 2, recipe_advanced_1, af_freon,1,prt_o_retardant_2,12,prt_o_retardant_6,12,copper,8
+x_af_cooler_up  			        = 2, recipe_advanced_1, af_cooler,1,prt_o_retardant_8,8,prt_o_retardant_17,8,prt_i_copper,8
+x_af_freon_up				        = 2, recipe_advanced_1, af_freon,1,prt_o_retardant_2,12,prt_o_retardant_6,12,prt_i_copper,8
 x_af_camelbak_up			        = 2, recipe_advanced_1, af_camelbak,1,prt_o_ballistic_10,4,prt_o_ballistic_14,4,prt_o_retardant_14,4
 x_af_surge_up 			            = 2, recipe_advanced_1, af_surge,1,prt_i_resistors,8,prt_i_scrap,8,prt_o_retardant_18,4
 
@@ -108,7 +108,7 @@ x_af_kevlar_up				        = 1, recipe_basic_1,     af_kevlar,1,prt_o_ballistic_1
 x_af_plates				            = 2, recipe_advanced_1,  af_kevlar_up,1,prt_o_ballistic_13,9,prt_o_ballistic_20,9,prt_o_ballistic_9,5
 x_af_plates_up				        = 3, recipe_expert_1,    af_plates,1,prt_o_ballistic_15,10,prt_o_ballistic_16,10,prt_o_ballistic_5,6
 
-x_batteries_exo                     = 1, recipe_expert_1,    ammo_gauss,2,copper,1,prt_i_fasteners,2,prt_i_scrap,2
+x_batteries_exo                     = 1, recipe_expert_1,    ammo_gauss,2,prt_i_copper,1,prt_i_fasteners,2,prt_i_scrap,2
 
 [3]
 title						= st_ui_craft_repair
@@ -135,7 +135,7 @@ x_heavy_repair_kit          = 3, recipe_expert_0, sewing_kit_a,8,heavy_sewing_th
 x_exo_repair_kit            = 3, recipe_ammo_4, heavy_repair_kit,10,sewing_kit_h,4,sewing_kit_a,8,sewing_kit_b,8
 x_toolkit_r7                = 3, recipe_expert_0, cleaning_kit_r7,20,solvent,7,ramrod_tool,6,steel_wool,4   ;  8928*5 + 13066 57706 RU / 75000 RU
 x_itm_advancedkit           = 1, recipe_basic_0, itm_basickit,5, prt_i_scrap,5
-x_itm_ammokit				= 1, recipe_basic_1,     itm_basickit,2,powder_3,6,bullet_r7_ap,6,copper,8
+x_itm_ammokit				= 1, recipe_basic_1,     itm_basickit,2,powder_3,6,bullet_r7_ap,6,prt_i_copper,8
 x_itm_drugkit				= 1, recipe_basic_1,     itm_basickit,2,medkit_scientic,3,rebirth,1,drug_anabiotic,1
 x_helm_cloth_mask			= 1, recipe_basic_0, prt_o_fabrics_1,5,prt_o_fabrics_2,5,prt_o_fabrics_3,5,sewing_thread,1
 
@@ -407,9 +407,9 @@ x_ammo_og-7b        		    = 5, recipe_expert_0, prt_i_scrap,3,ied_rpg_new,2
 x_mine_new       				    = 5, recipe_ammo_0, prt_i_scrap,4,grenade_f1,1
 x_ied_rpg_new      			        = 5, recipe_ammo_0, grenade_f1,1,grenade_rgd5,2,prt_i_scrap,2
 x_ied_new      				        = 5, recipe_ammo_0, ammo_vog-25,1,grenade_f1,1,prt_i_scrap,2
-a_ammo_gauss				    = 5, recipe_expert_0, af_ring,1,copper,1,prt_i_scrap,2,batteries_dead,3
-b_ammo_gauss				    = 5, recipe_expert_0, af_dummy_battery,2,copper,1,prt_i_scrap,2,batteries_dead,3
-c_ammo_gauss				    = 5, recipe_expert_0, af_electra_sparkler,2,copper,1,prt_i_scrap,2,batteries_dead,3
+a_ammo_gauss				    = 5, recipe_expert_0, af_ring,1,prt_i_copper,1,prt_i_scrap,2,batteries_dead,3
+b_ammo_gauss				    = 5, recipe_expert_0, af_dummy_battery,2,prt_i_copper,1,prt_i_scrap,2,batteries_dead,3
+c_ammo_gauss				    = 5, recipe_expert_0, af_electra_sparkler,2,prt_i_copper,1,prt_i_scrap,2,batteries_dead,3
 a_ammo_m209   = 5, recipe_advanced_0, ammo_vog-25,1,prt_i_scrap,2,powder_3,1
 b_ammo_m209   = 5, recipe_advanced_0, ammo_vog-30,1,prt_i_scrap,2,powder_3,1
 a_ammo_vog-25 = 5, recipe_advanced_0, ammo_m209,1,prt_i_scrap,2,powder_3,1


### PR DESCRIPTION
Fix for CTD when attempting to craft these recipes.