### PR TITLE
fix: use dolg_sim_squad_alpha in zat_b5 spawn_duty respawn

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/zaton/smart/zat_b5_smart_terrain.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/zaton/smart/zat_b5_smart_terrain.ltx
@@ -9,7 +9,7 @@ respawn_idle = 57600
 spawn_duty
 
 [spawn_duty]
-spawn_squads = duty_sim_squad_alpha, duty_sim_squad_veteran, duty_sim_squad_5, army_sim_squad_alpha
+spawn_squads = dolg_sim_squad_alpha, duty_sim_squad_veteran, duty_sim_squad_5, army_sim_squad_alpha
 spawn_num = {+living_legend_psy_helmet} 2, 1
 
 [exclusive]


### PR DESCRIPTION
## Problem

`G.A.M.M.A. NPC Spawns/.../zat_b5_smart_terrain.ltx` lists `duty_sim_squad_alpha` in `[spawn_duty].spawn_squads`, but no section by that name exists:

- Vanilla Anomaly defines the alpha as `[dolg_sim_squad_alpha]` (faction internal name `dolg`).
- Dux's Innemurable Characters Kit adds `duty_sim_squad_novice`, `duty_sim_squad_advanced`, `duty_sim_squad_veteran`, `duty_sim_squad_5` — no `_alpha` variant.

When `zat_b5` rolls the alpha entry from `spawn_duty`, the engine raises:

```
!ERROR: alife_create | section [duty_sim_squad_alpha] is invalid!
```

Reported in `#gamma-help` by a user who confirmed only `dolg_sim_squad_alpha` exists in their squad config.

## Fix

One-line change: `duty_sim_squad_alpha` -> `dolg_sim_squad_alpha` on `[spawn_duty].spawn_squads` in `zat_b5_smart_terrain.ltx`. The other three entries (`duty_sim_squad_veteran`, `duty_sim_squad_5`, `army_sim_squad_alpha`) are valid sections and unchanged.

Introduced in 67d2631b2 ("Duty and Army now occupies zat_b5 smart (Ranger Station)").

## Note

The `xcvb's Guards Spawner` and `ZCP smr_pop.script` both carry a `duty_sim_squad_alpha -> dolg_sim_squad_alpha` rename table, but those guards only apply to squad sections those scripts construct themselves — they don't intercept squad sections read directly from smart-terrain `spawn_squads` lists by engine code.