### PR TITLE
DAO: vanilla anomaly cache, db.actor guard, kd_tree cleanup

### DIFF
--- a/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/drx_da_main.script
+++ b/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/drx_da_main.script
@@ -412,6 +412,9 @@ anomaly_radii = {
 updated_anomaly_levels = {}
 last_surge_time = 0
 
+local vanilla_anomaly_cache = {}
+local vanilla_cache_built = {}
+
 function init_anomaly_table_on_level(level_name)
 	local level_name = level_name or level.name()
 	if not updated_anomaly_levels[level_name] then updated_anomaly_levels[level_name] = {} end
@@ -881,7 +884,7 @@ function clean_dynamic_anomalies_global()
 						if IsAnomaly(_, se_obj:clsid()) then
 							printf("Deleting anomaly %s, %s globally, level %s", se_obj:section_name(), v1, k)
 							alife_record(se_obj ,false)
-							alife():release(se_obj, true)
+							sim:release(se_obj, true)
 						else
 							printf("Error, object is not an anomaly, %s, %s, on level %s", se_obj:section_name(), v1, k)
 						end
@@ -918,7 +921,7 @@ function clean_dynamic_anomalies_global()
 									local o = alife_object(anom_id)
 									if o then 
 										alife_record(o ,false)
-										alife():release(o, true)
+										sim:release(o, true)
 									end
 								else
 									printf("Error, can't remove old anomaly %s, level %s, in restriction", anom_id, k)
@@ -1100,7 +1103,7 @@ function drx_da_spawn_anomalies_on_level(level_name)
 	if is_not_empty(rad_fields) then
 		for i = 1, math.ceil(#rad_fields / 2) do
 			if is_empty(rad_fields) then break end
-			anomaly_list[#anomaly_list + 1] = table_remove(rad_fields, math.random(#rad_fields))
+			anomaly_list[#anomaly_list + 1] = table_remove(rad_fields, random(#rad_fields))
 		end
 	end
 
@@ -1725,8 +1728,9 @@ function register_anomalies_behaviour()
 
 	printf("anomalies behaviour, turning on behaviour for level %s", level_name)
 
+	local now = time_global()
 	for k, v in pairs(updated_anomaly_levels[level_name].anomalies_properties) do
-		v.update_time = time_global()
+		v.update_time = now
 	end
 
 	local get_object = level.object_by_id
@@ -1786,34 +1790,69 @@ common_sec = {
 }
 
 function build_anomalies_pos_tree()
-	local alife_release_id = alife_release_id
 	local gg = game_graph()
 	local gg_vertex = gg.vertex
 	local level_name = level.name()
-	local load_var = load_var
 	local pairs = pairs
-	local printf = printf
 	local sim = alife()
+	if not sim then return end
 	local sim_level_name = sim.level_name
 	local sim_object = sim.object
-	local sim_release = sim.release
-	local alife_record = alife_record
-	local strformat = strformat
-
-	local level_name = level.name()
 
 	local objects = {}
 	local obj_to_pos = {}
 	local sec_to_obj = {}
 
-	
+	local all_anomaly_ids = {}
 
-	for i = 1, 65534 do
-		local obj = get_anomaly_obj(i, level_name)
+	if updated_anomaly_levels[level_name] and updated_anomaly_levels[level_name].anomalies then
+		for _, id in pairs(updated_anomaly_levels[level_name].anomalies) do
+			if id and type(id) == "number" then
+				all_anomaly_ids[id] = true
+			end
+		end
+	end
+
+	if bind_anomaly_field and bind_anomaly_field.dyn_anomalies then
+		local ssfx_anomalies = bind_anomaly_field.dyn_anomalies[level_name]
+		if ssfx_anomalies then
+			for id, _ in pairs(ssfx_anomalies) do
+				if id and type(id) == "number" then
+					all_anomaly_ids[id] = true
+				end
+			end
+		end
+	end
+
+	if not vanilla_cache_built[level_name] then
+		vanilla_anomaly_cache[level_name] = {}
+		for i = 1, 65534 do
+			local se_obj = sim_object(sim, i)
+			if se_obj then
+				local cls = se_obj:clsid()
+				if IsAnomaly(_, cls) then
+					local obj_level = sim_level_name(sim, gg_vertex(gg, se_obj.m_game_vertex_id):level_id())
+					if obj_level == level_name and not all_anomaly_ids[i] then
+						vanilla_anomaly_cache[level_name][i] = true
+					end
+				end
+			end
+		end
+		vanilla_cache_built[level_name] = true
+	end
+
+	if vanilla_anomaly_cache[level_name] then
+		for id, _ in pairs(vanilla_anomaly_cache[level_name]) do
+			all_anomaly_ids[id] = true
+		end
+	end
+
+	for id, _ in pairs(all_anomaly_ids) do
+		local obj = get_anomaly_obj(id, level_name)
 		if obj then
 			table.insert(objects, obj)
-			obj_to_pos[i] = {
-				id = i,
+			obj_to_pos[id] = {
+				id = id,
 				section = obj:section_name(),
 				position = obj.position
 			}
@@ -1821,10 +1860,12 @@ function build_anomalies_pos_tree()
 			sec = common_sec[sec] or sec
 			if not sec_to_obj[sec] then sec_to_obj[sec] = {} end
 			table.insert(sec_to_obj[sec], {
-				id = i,
+				id = id,
 				section = obj:section_name(),
 				position = obj.position
 			})
+		elseif vanilla_anomaly_cache[level_name] then
+			vanilla_anomaly_cache[level_name][id] = nil
 		end
 	end
 
@@ -1978,12 +2019,13 @@ anomalies_near_actor_functions = {
 
 		if random() * 100 <= 0.5 then
 			anomaly.spawn_time = time_elapsed + spawn_cooldown
+			local actor_position = actor:position()
+			local actor_gvid = alife():actor().m_game_vertex_id
 			for i = 1, ceil(random() ^ 2 * spawn_max_amount) do
-				local actor_position = actor:position()
 				local spawn_position = vector():set(actor_position.x - random_float(5, 7), actor_position.y, actor_position.z - random_float(5, 7))
 				local spawn_section = spawn_table[random(#spawn_table)]
 
-				alife_create(spawn_section, spawn_position, level_vertex_id(spawn_position), alife():actor().m_game_vertex_id)
+				alife_create(spawn_section, spawn_position, level_vertex_id(spawn_position), actor_gvid)
 			end
 		end
 	end,
@@ -3407,7 +3449,7 @@ function force_clean_dynamic_anomalies_global()
 						if IsAnomaly(_, se_obj:clsid()) then
 							printf("Deleting anomaly %s, %s globally, level %s", se_obj:section_name(), v1, k)
 							alife_record(se_obj ,false)
-							alife():release(se_obj, true)
+							sim:release(se_obj, true)
 						else
 							printf("Error, object is not an anomaly, %s, %s, on level %s", se_obj:section_name(), v1, k)
 						end
@@ -3444,7 +3486,7 @@ function force_clean_dynamic_anomalies_global()
 									local o = alife_object(anom_id)
 									if o then 
 										alife_record(o ,false)
-										alife():release(o, true)
+										sim:release(o, true)
 									end
 								else
 									printf("Error, can't remove old anomaly %s, level %s, in restriction", anom_id, k)

--- a/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/kd_tree.script
+++ b/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/kd_tree.script
@@ -1,0 +1,571 @@
+-- https://github.com/ubilabs/kd-tree-javascript
+-- k-d Tree Implementation for Lua for quick search in multidimensional tables
+-- k-d trees are a useful data structure for several applications, such as searches involving a multidimensional search key (e.g. range searches and nearest neighbor searches). k-d trees are a special case of binary space partitioning trees.
+-- Rewritten to pure Lua and adapted for usage in Anomaly by demonized
+
+local math_floor = math.floor
+local math_log = math.log
+local math_max = math.max
+local math_min = math.min
+
+local table_insert = table.insert
+local table_remove = table.remove
+local table_sort = table.sort
+
+local empty_table = empty_table
+
+local pairs = pairs
+
+local function table_slice(t, first, last)
+    local res = {}
+    for i = first or 1, last and last - 1 or #t do
+        res[#res + 1] = t[i]
+    end
+    return res
+end
+
+-- http://lua-users.org/wiki/BinaryInsert
+local function binary_insert(t, value, fcomp)
+    -- Initialise compare function
+    local fcomp = fcomp or function(a, b) return a < b end
+
+    -- print_table(value)
+
+    --  Initialise numbers
+    local iStart, iEnd, iMid, iState = 1, #t, 1, 0
+
+    if iEnd == 0 then
+        t[1] = value
+        -- printf("adding in beginning table empty")
+        return 1
+    end
+
+    if fcomp(value, t[1]) then
+        -- printf("adding in beginning %s of %s", 1, iEnd)
+        table_insert(t, 1, value)
+        return 1
+    end
+
+    if not fcomp(value, t[iEnd]) then
+        -- printf("adding in end %s of %s", iEnd + 1, iEnd)
+        local pos = iEnd + 1
+        t[pos] = value
+        return pos
+    end
+
+    -- Get insert position
+    while iStart <= iEnd do
+
+        -- calculate middle
+        iMid = math_floor((iStart + iEnd) / 2)
+
+        -- compare
+        if fcomp(value, t[iMid]) then
+            iEnd, iState = iMid - 1, 0
+        else
+            iStart, iState = iMid + 1, 1
+        end
+    end
+
+    local pos = iMid + iState
+    -- printf("adding in middle %s of %s", pos, iEnd)
+    table_insert(t, pos, value)
+    return pos
+end
+
+function Node(obj, dimension, parent)
+    local node = {}
+
+    node.obj = obj
+    node.left = nil
+    node.right = nil
+    node.parent = parent
+    node.dimension = dimension
+
+    return node
+end
+
+function kdTree(points, metric, dimensions)
+    local kd_tree = {}
+
+    kd_tree.points = points or {}
+    kd_tree.metric = metric
+    kd_tree.dimensions = dimensions
+
+    local function buildTree(new_points, depth, parent)
+        local dim = (depth % #dimensions) + 1
+        local median
+        local node
+
+        if not new_points then 
+            return
+        end
+
+        if #new_points == 0 then
+            -- printf("buildTree #new_points == 0")
+            return
+        end
+
+        if #new_points == 1 then
+            -- printf("buildTree #new_points == 1")
+            return Node(new_points[1], dim, parent)
+        end
+
+        table_sort(new_points, function(a, b)
+            return a[dimensions[dim]] < b[dimensions[dim]]
+        end)
+
+        median = math_floor(#new_points / 2) + 1
+        node = Node(new_points[median], dim, parent)
+        node.left = buildTree(table_slice(new_points, 1, median), depth + 1, node)
+        node.right = buildTree(table_slice(new_points, median + 1), depth + 1, node)
+
+        return node
+    end
+
+    kd_tree.root = buildTree(points, 0, nil)
+
+    kd_tree.insertAndRebuild = function(self, point)
+        self.points[#self.points + 1] = point
+        self.root = buildTree(self.points, 0, nil)
+        return self
+    end
+
+    kd_tree.insert = function(self, point)
+        local function innerSearch(node, parent)
+
+            if node == nil then
+                return parent
+            end
+
+            local dimension = self.dimensions[node.dimension]
+            if point[dimension] < node.obj[dimension] then
+                return innerSearch(node.left, node)
+            else
+                return innerSearch(node.right, node)
+            end
+        end
+
+        local insertPosition = innerSearch(self.root, nil)
+        local newNode
+        local dimension
+
+        if insertPosition == nil then
+            self.points[#self.points + 1] = point
+            self.root = buildTree(self.points, 0, nil)
+            return self
+        end
+
+        newNode = Node(point, (insertPosition.dimension + 1) % #self.dimensions, insertPosition)
+        dimension = self.dimensions[insertPosition.dimension]
+
+        if point[dimension] < insertPosition.obj[dimension] then
+            insertPosition.left = newNode
+        else
+            insertPosition.right = newNode
+        end
+
+        self.points[#self.points + 1] = point
+
+        return self
+    end
+
+    kd_tree.remove = function(self, point)
+        local node
+
+        local function nodeSearch(node)
+            if node == nil then
+                return
+            end
+
+            if node.obj == point then
+                return node
+            end
+
+            local dimension = self.dimensions[node.dimension]
+
+            if point[dimension] < node.obj[dimension] then
+                return nodeSearch(node.left)
+            else
+                return nodeSearch(node.right)
+            end
+        end
+
+        local function removeNode(node)
+            local nextNode
+            local nextObj
+            local pDimension
+
+            local function findMin(node, dim)
+                local dimension
+                local own
+                local left
+                local right
+                local min
+
+                if node == nil then
+                    return
+                end
+
+                dimension = self.dimensions[dim]
+
+                if node.dimension == dim then
+                    if node.left ~= nil then
+                        return findMin(node.left, dim)
+                    end
+                    return node
+                end
+
+                own = node.obj[dimension]
+                left = findMin(node.left, dim)
+                right = findMin(node.right, dim)
+                min = node
+
+                if left ~= nil and left.obj[dimension] < own then
+                    min = left
+                end
+
+                if right ~= nil and right.obj[dimension] < min.obj[dimension] then
+                    min = right
+                end
+
+                return min
+            end
+
+            if node.left == nil and node.right == nil then
+                if node.parent == nil then
+                    self.root = nil
+                    return
+                end
+
+                pDimension = self.dimensions[node.parent.dimension]
+
+                if node.obj[pDimension] < node.parent.obj[pDimension] then
+                    node.parent.left = nil
+                else
+                    node.parent.right = nil
+                end
+                return
+            end
+
+            -- If the right subtree is not empty, swap with the minimum element on the
+            -- node's dimension. If it is empty, we swap the left and right subtrees and
+            -- do the same.
+            if node.right ~= nil then
+                nextNode = findMin(node.right, node.dimension)
+                nextObj = nextNode.obj
+                removeNode(nextNode)
+                node.obj = nextObj
+            else 
+                nextNode = findMin(node.left, node.dimension)
+                nextObj = nextNode.obj
+                removeNode(nextNode)
+                node.right = node.left
+                node.left = nil
+                node.obj = nextObj
+            end
+        end
+
+        node = nodeSearch(self.root)
+
+        if node == nil then
+            return
+        end
+
+        removeNode(node)
+
+        return self
+    end
+
+    kd_tree.clearRoot = function(self)
+        empty_table(self.root)
+        return self
+    end
+
+    -- Update positions of objects
+    -- Points input must be same structure as existing in k-d Tree
+
+    kd_tree.updatePositions = function(self, points)
+        self.points = points
+        self:clearRoot()
+        self.root = buildTree(points, 0, nil)
+        return self
+    end
+
+    -- get all points sorted by nearest
+    kd_tree.nearestAll = function(self, point)
+        local point = {
+            x = point.x or point[1],
+            y = point.y or point[2],
+            z = point.z or point[3]
+        }
+
+        local function comp_function(a, b)
+            return a[2] < b[2]
+        end
+
+        local res = {}
+        for i = 1, #self.points do
+            local v = self.points[i]
+            res[i] = {
+                [1] = {
+                    x = v.x,
+                    y = v.y,
+                    z = v.z,
+                    data = v.data
+                },
+                [2] = math.huge
+            }
+            res[i][2] = self.metric(res[i][1], point)
+        end
+        table_sort(res, comp_function)
+        
+        return res
+    end
+
+    -- Query the nearest *count* neighbours to a point, with an optional
+    -- maximal search distance.
+    -- Result is an array with *count* elements.
+    -- Each element is an array with two components: the searched point and
+    -- the distance to it.
+
+    kd_tree.nearest = function(self, point, maxNodes, maxDistance)
+        local i
+        local result
+        local bestNodes
+
+        bestNodes = {}
+        local passedNodes = {}
+
+        local maxNodes = maxNodes or 1
+
+        local function comp_function(a, b) 
+            return a[2] < b[2]
+        end 
+
+        local function saveNode(node, distance)
+            binary_insert(bestNodes, {node, distance}, comp_function)
+            if #bestNodes > maxNodes then
+                table_remove(bestNodes)
+            end
+        end
+
+        local function nearestSearch(node)
+            if passedNodes[node] then return end
+
+            local bestChild
+            local dimension = self.dimensions[node.dimension]
+            local ownDistance = self.metric(point, node.obj)
+            local linearPoint = {}
+            local linearDistance
+            local otherChild
+            local i            
+
+            for i = 1, #self.dimensions do
+                linearPoint[self.dimensions[i]] = i == node.dimension and point[self.dimensions[i]] or node.obj[self.dimensions[i]]
+            end
+
+            linearDistance = self.metric(linearPoint, node.obj)
+
+            if node.right == nil and node.left == nil then
+                if #bestNodes < maxNodes or ownDistance < bestNodes[#bestNodes][2] then
+                    saveNode(node, ownDistance)
+                end
+                passedNodes[node] = true
+                return
+            end
+
+            if node.right == nil then
+                bestChild = node.left
+            elseif node.left == nil then
+                bestChild = node.right
+            else
+                bestChild = point[dimension] < node.obj[dimension] and node.left or node.right
+            end
+
+            nearestSearch(bestChild)
+
+            if #bestNodes < maxNodes or ownDistance < bestNodes[#bestNodes][2] then
+                saveNode(node, ownDistance)
+                passedNodes[node] = true
+            end
+
+            if #bestNodes < maxNodes or math.abs(linearDistance) < bestNodes[1][2] then
+                otherChild = bestChild == node.left and node.right or node.left
+                if (otherChild ~= nil) then
+                    nearestSearch(otherChild)
+                end
+            end
+        end
+
+        if maxDistance then
+            for i = 1, maxNodes do
+                bestNodes[i] = {nil, maxDistance}
+            end
+        end
+
+        if self.root then
+            nearestSearch(self.root)
+        end
+
+        result = {}
+        for i = 1, math_min(maxNodes, #bestNodes) do
+            if bestNodes[i][1] then
+                result[#result + 1] = {
+                    bestNodes[i][1].obj,
+                    bestNodes[i][2]
+                }
+            end
+        end
+
+        return result
+    end
+
+    -- Get an approximation of how unbalanced the tree is.
+    -- The higher this number, the worse query performance will be.
+    -- It indicates how many times worse it is than the optimal tree.
+    -- Minimum is 1. Unreliable for small trees.
+
+    kd_tree.balanceFactor = function(self)
+        local function height(node)
+            if node == nil then
+                return 0
+            end
+            return math_max(height(node.left), height(node.right)) + 1
+        end
+
+        local function count(node)
+            if node == nil then
+                return 0
+            end
+            return count(node.left) + count(node.right) + 1
+        end
+
+        return height(self.root) / (math_log(count(self.root)) / math_log(2))
+    end
+
+    return kd_tree
+end
+
+local function distance_to(a, b)
+    -- printf("distance_to fired")
+
+    local dist_x = a.x - b.x
+    local dist_y = a.y - b.y
+    local dist_z = a.z - b.z
+    
+    return dist_x * dist_x + dist_y * dist_y + dist_z * dist_z
+end
+
+-- Actual usage starts here
+--[[
+
+When you build position tree, you can find nearest objects in relation to other objects
+Example, find nearest position to actor:
+    local pos_tree = kd_tree.buildTreeObjectIds({45, 65, 23, 5353, 232})
+    print_table(pos_tree:nearest(db.actor:position()))
+
+will print position, distance and id of nearest object from given ids
+
+--]]
+
+-- Build k-d Tree by several inputs
+-- Input - Array of vectors (vector():set(x, y, z) or table with x, y, z keys or 1, 2, 3 keys)
+-- Data is an optional table where you can bind your data to your object, must have same amount of fields as vectors (#vectors == #data)
+function buildTreeVectors(vectors, data)
+    local v = {}
+    local data = data or {}
+    local vectors = vectors or {}
+    for k, t in pairs(vectors) do
+        table_insert(v, {
+            x = t.x or t[1],
+            y = t.y or t[2],
+            z = t.z or t[3],
+            data = data[k]
+        })
+    end
+    -- printf("vectors num %s", #v)
+    return kdTree(v, distance_to, {"x", "y", "z"})
+end
+
+-- Input - Array of game objects
+-- Vectors are binded to object ids automatically
+function buildTreeObjects(objects)
+    local vectors = {}
+    local data = {}
+    for k, v in pairs(objects) do
+        table_insert(vectors, v:position())
+        table_insert(data, v:id())
+    end
+    return buildTreeVectors(vectors, data)
+end
+
+-- Input - Array of server objects
+-- Vectors are binded to object ids automatically
+function buildTreeSeObjects(objects)
+    local vectors = {}
+    local data = {}
+    for k, v in pairs(objects) do
+        table_insert(vectors, v.position)
+        table_insert(data, v.id)
+    end
+    return buildTreeVectors(vectors, data)
+end
+
+-- Input - Array of game object ids
+-- Vectors are binded to object ids automatically
+function buildTreeObjectIds(ids)
+    local vectors = {}
+    local data = {}
+    local level_object_by_id = level.object_by_id
+    for k, v in pairs(ids) do
+        local obj = level_object_by_id(v)
+        if obj and obj ~= 0 and obj:id() ~= 0 then 
+            table_insert(vectors, obj:position())
+            table_insert(data, v)
+        end
+    end
+    return buildTreeVectors(vectors, data)
+end
+
+-- Input - Array of server object ids
+-- Vectors are binded to object ids automatically
+function buildTreeSeObjectIds(ids)
+    local vectors = {}
+    local data = {}
+    local sim = alife()
+    local sim_object = sim.object
+    for k, v in pairs(ids) do
+        local obj = sim_object(sim, v)
+        if obj and obj ~= 0 and obj.id ~= 0 then 
+            table_insert(vectors, obj.position)
+            table_insert(data, v)
+        end
+    end
+    return buildTreeVectors(vectors, data)
+end
+
+-- If you build a tree using functions above
+-- You can use this function to update positions and rebuild the tree 
+function updateObjPositions(kd_tree)
+    local points = kd_tree.points
+    local new_points = {}
+
+    local sim = alife()
+    local sim_object = sim.object
+    for i = 1, #points do
+        local obj = sim_object(sim, points[i].data)
+        if obj then
+            local pos = obj.position
+            table_insert(new_points, {
+                x = pos.x,
+                y = pos.y,
+                z = pos.z,
+                data = points[i].data
+            })
+        end
+    end
+
+    kd_tree:updatePositions(new_points)
+    return kd_tree
+end

--- a/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/speed.script
+++ b/G.A.M.M.A/modpack_addons/234- Dynamic Anomalies Overhaul - Demonized/gamedata/scripts/speed.script
@@ -1,0 +1,78 @@
+local speeds = {}
+local sprint_modifiers = {}
+local run_modifiers = {}
+local not_first_update = true
+
+local function actor_on_first_update()
+    if not db.actor then return end
+    speeds[0] = db.actor:get_actor_run_coef()
+    speeds[1] = db.actor:get_actor_runback_coef()
+    speeds[2] = db.actor:get_actor_sprint_koef()
+    not_first_update = false
+end
+
+
+function on_game_start()
+	RegisterScriptCallback("actor_on_first_update",actor_on_first_update)
+end 
+local function update_speeds()
+    if not db.actor then return end
+    if not_first_update then
+        actor_on_first_update()
+        if not_first_update then return end
+    end
+    local run_coef = 1
+    for k,v in pairs(run_modifiers) do
+        run_coef = run_coef * v
+    end
+    local sprint_coef = 1
+    for k,v in pairs(sprint_modifiers) do
+        sprint_coef = sprint_coef * v
+    end
+    db.actor:set_actor_run_coef(clamp(speeds[0] * run_coef, 1, 10))
+    db.actor:set_actor_runback_coef(clamp(speeds[1] * run_coef, 1, 10))
+    db.actor:set_actor_sprint_koef(clamp(speeds[2] * sprint_coef, 1, 10))
+end
+
+-- Usage: Add a speed modifier.
+-- Once a speed modifier is added, speed will be recalculated and set.
+-- run_modifiers affects run and runback, sprint_modifiers affects sprint
+-- Params:
+-- speed_key - Name of speed multiplier you want to add
+-- speed_mult - Speed multiplier as a number (e.g. 0.5 will halve speed)
+-- is_sprint - Boolean, if true adds to sprint modifier and updates accordingly, false adds to run modifier
+-- force - Boolean, will overwrite existing speed.
+-- Returns true if speed added successfully, false if key already exists (and nothing happens as result)
+function add_speed(speed_key, speed_mult, is_sprint, force)
+    if (is_sprint) then
+        if force or not sprint_modifiers[speed_key] then
+            -- printf("sprint: " .. speed_key .. " " .. speed_mult)
+            sprint_modifiers[speed_key] = speed_mult
+            update_speeds()
+            return true
+        else
+            return false
+        end
+    else
+        if force or not run_modifiers[speed_key] then
+            run_modifiers[speed_key] = speed_mult
+            update_speeds()
+            return true
+        else
+            return false
+        end
+    end
+end
+
+-- Usage: Drop a speed modifier. Once a speed modifier is dropped, speed will be recalculated and set. 
+-- Params
+-- speed_key - Name of speed multiplier to drop. Will drop from both tables.
+function remove_speed(speed_key)
+    if sprint_modifiers[speed_key] then
+        sprint_modifiers[speed_key] = nil
+    end
+    if run_modifiers[speed_key] then
+        run_modifiers[speed_key] = nil
+    end
+    update_speeds()
+end


### PR DESCRIPTION
GAMMA didn't patch speed.script or kd_tree.script before, so they show up as new files here. Actual diffs vs upstream are 3 and 2 lines.

### drx_da_main.script

- (perf) `build_anomalies_pos_tree`: caches vanilla anomaly ids per level. The 1..65534 alife_object scan now runs once per level visit (on first call). Subsequent calls during the visit (surges, force-cleans, resets) walk the cache plus DAO-tracked and SSFX dynamic ids. Stale entries clear when `get_anomaly_obj` returns nil. Removes the recurring stutter on mid-visit events. The scan cost on level entry is unchanged.
- (micro-perf) :1103 use file-local `random` in the rad_fields shuffle
- (micro-perf) :1729 pull `time_global()` out of the update_time loop
- (micro-perf) :884, 921, 3410, 3447 use cached `sim:release` instead of re-calling `alife()` per iteration (sim is already local in both functions)
- (micro-perf) :1986 pull `actor:position()` and `alife():actor().m_game_vertex_id` out of the poltergeist spawn loop

### speed.script

- (crash) nil-guard `db.actor` in `actor_on_first_update` and `update_speeds`. `add_speed` and `remove_speed` are public API hit by other mods. `db.actor` is nil between Lua VM init and the first actor update, and the window reopens on every level change since the VM restarts. Without the guard, any TimeEvent or post-unload callback that hits these during that window CTDs.
- (defensive) `update_speeds` re-checks `not_first_update` after the lazy init so it bails cleanly if `actor_on_first_update` returned early.

### kd_tree.script

- (cleanup, no functional change) :188, :190 drop the unused second arg in `nodeSearch` recursion. Function declared with one param, called with two. Extra arg gets dropped. `removeNode` reads `node.parent` off the tree directly, so the descent doesn't need to track parent.