### PR TITLE
Keep Crafting Window Opened: OnCook/OnRepair nil guard, IsItem hoist + cache

### DIFF
--- a/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_item_cooking_keep_crafting_window_open.script
+++ b/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_item_cooking_keep_crafting_window_open.script
@@ -1,0 +1,299 @@
+--_size from item_cooking file, local var there by default
+-- if that changes then it needs to be changed here also
+local _size = item_cooking._size or 2 -- number of Ingredients (not counting fuel)
+
+local IsItem = IsItem
+
+local InitControlsSuper = item_cooking.UICook.InitControls
+item_cooking.UICook.InitControls = function(self)
+	InitControlsSuper(self)
+	self.hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.multiUseItemsObj = {}
+	self.multiUseItemsUses = 0
+	self.fuelCount = 0
+	-- printf("calling override InitControls")
+end
+
+item_cooking.UICook.CollectValidItems = function(self, obj, section)
+	-- Collect valid items
+	empty_table(self.multiUseItemsObj)
+	local parts_id = {}
+	local is_multiuse = IsItem("multiuse", section, nil)
+	local function search(temp, item)
+		if (item:section() == section) and (not parts_id[item:id()]) then
+			local cnt = is_multiuse and item:get_remaining_uses() or 1
+			local id = item:id()
+			parts_id[id] = cnt
+			self.multiUseItemsObj[#self.multiUseItemsObj + 1] = {
+				[id]=cnt
+			}
+		end
+	end
+	db.actor:iterate_inventory(search,nil)
+	-- print_r(self.multiUseItemsObj)
+
+	-- Collect Uses
+	self.multiUseItemsUses = 0
+	for _,cnt in pairs(parts_id) do
+		self.multiUseItemsUses = self.multiUseItemsUses + cnt
+	end
+
+	-- Write amount of uses near cooking item name
+	local str = ui_item.get_sec_name(section)
+	if (self.cooking_limited) then
+		local color = ""
+		if self.multiUseItemsUses > 3 then
+			color = utils_xml.get_color("d_green")
+		elseif self.multiUseItemsUses > 2 then
+			color = utils_xml.get_color("pda_yellow")
+		elseif self.multiUseItemsUses > 1 then
+			color = utils_xml.get_color("d_orange")
+		else
+			color = utils_xml.get_color("d_red")
+		end
+		str = color .. str .. " (" .. self.multiUseItemsUses .. ")"
+	end
+	self.cap_menu:SetText(str)
+
+	return true
+end
+
+
+local ResetSuper = item_cooking.UICook.Reset
+item_cooking.UICook.Reset = function(self, obj, section)
+	ResetSuper(self, obj, section)
+	-- Set cooking kit name, uses and icon, store uses
+	-- Delay because of alife shenanigans when using multiuse items with
+	-- heavy scripting like this
+	CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.CollectValidItems, self, obj, section)
+	--self:CollectValidItems(obj, section)
+	-- printf("Calling override Reset")
+	return true
+end
+
+local On_CC_Mouse1Super = item_cooking.UICook.On_CC_Mouse1
+item_cooking.UICook.On_CC_Mouse1 = function(self, cont, idx)
+	On_CC_Mouse1Super(self, cont, idx)
+
+	-- printf("calling override On_CC_Mouse1")
+	local ci = self.CC.cell[idx]
+	if (not ci) then
+		return
+	end
+	
+	-- Get meal props
+	local sec = ci.section
+	local meal = self:GetSelectedMeal()
+	if (not meal) then
+		return
+	end
+
+	-- Add amount of fuel available in window near fuel title
+	local fuel_tier = meal.fuel_tier
+	local fuel_type = self:GetAvailFuel(fuel_tier)
+	local ingre_clr = self:CheckAvailFuel(fuel_tier) and self.clr["g"] or self.clr["r"]
+
+	self.fuelCount = 0
+
+	for sec,_ in pairs(self.cooking_fuel) do
+		if self.fuel[sec] and (fuel_tier <= self.fuel[sec]) and self:CheckAvail(sec, 1) then
+			self.fuelCount = self.fuelCount + self:GetAvail(sec)
+		end
+	end
+
+	local color = ""
+	if not self.is_campfire then
+		if self.fuelCount > 3 then
+			color = utils_xml.get_color("d_green")
+		elseif self.fuelCount > 2 then
+			color = utils_xml.get_color("pda_yellow")
+		elseif self.fuelCount > 1 then
+			color = utils_xml.get_color("d_orange")
+		else
+			color = utils_xml.get_color("d_red")
+		end
+	end
+	
+	-- if at campfire then *, otherwise show fuel count
+	self.ingre_name[1]:SetText(color .. ui_item.get_sec_name(fuel_type) .. " (" .. (self.is_campfire and "*" or self.fuelCount) .. ")")
+	utils_xml.set_icon(fuel_type, ingre_clr == self.clr["r"], self.ingre_ico_temp[1], self.ingre_ico[1])
+
+	self.last_cont = cont
+	self.last_idx = idx
+	return true
+end
+
+item_cooking.UICook.CheckHasCookingIngredients = function(self) 
+	local meal = self:GetSelectedMeal()
+
+	if (self.multiUseItemsUses == 0) then
+		return false
+	end
+
+	if (not self:CheckAvailFuel(meal.fuel_tier)) then
+		return false
+	end
+
+	local meal_items = {}
+	local inventory = {}
+	for i, item in ipairs(meal) do
+		meal_items[item["sec"]] = item["amt"]
+		inventory[item["sec"]] = 0
+	end
+
+	-- print_r(self.objs)
+	-- printf("...")
+	-- print_r(meal_items)
+
+	for meal_ingredient, meal_ingredient_amt in pairs(meal_items) do
+		if (self.objs[meal_ingredient]) then
+			for id, amount in pairs(self.objs[meal_ingredient]) do
+				inventory[meal_ingredient] = inventory[meal_ingredient] + amount
+			end
+			if (inventory[meal_ingredient] < meal_items[meal_ingredient]) then
+				return false
+			end
+		else
+			return false
+		end
+	end
+	return true
+end
+
+item_cooking.UICook.UpdateUi = function(self)
+	-- printf("UpdateUI triggered")
+
+	--close on last use otherwise script bork the game
+	if (self.cooking_limited and self.multiUseItemsUses == 1) then
+		self:Close()
+		return true
+	end
+
+	empty_table(self.objs)
+	self:Load_ActorItems()
+	self:CollectValidItems(self.obj, self.section)
+	-- printf(self.multiUseItemsUses)
+	
+	self:On_CC_Mouse1(self.last_cont, self.last_idx)
+	if (self:CheckHasCookingIngredients()) then
+		-- printf("has Ingredients updating")	
+	else
+		-- printf("hasn't Ingredients reseting")
+		empty_table(self.meals)
+		self:Load_MealRecipes()
+		self:Load_MealList()
+		self.btn_cook:Enable(false)
+		self:Update()
+		
+		--self:Reset(self.obj, self.section)
+	end
+	return true
+end
+
+item_cooking.UICook.OnCook = function(self)
+	-- printf("Calling override OnCook")
+	local meal = self:GetSelectedMeal()
+	if (not meal) then
+		return
+	end
+
+	self:CollectValidItems(self.obj, self.section)
+
+	-- Discharge cooking fuel if its not a campfire
+	if (not self.is_campfire) then
+		local sec_fuel = self:GetAvailFuel(meal.fuel_tier, true)
+		local id_fuel = sec_fuel and random_key_table(self.objs[sec_fuel])
+		if id_fuel then
+			local obj_fuel = get_object_by_id(id_fuel)
+			if obj_fuel then
+				utils_item.discharge(obj_fuel)
+			end
+		end
+	end
+	
+	-- Discharge Ingredients
+	for i=1,_size do
+		if meal[i] then
+			local sec = meal[i].sec
+			local amt = meal[i].amt
+			local stop
+			for id,uses in pairs(self.objs[sec]) do
+				if stop then
+					break
+				end
+				
+				if ((amt - uses) >= 0) then
+					local se_obj = alife_object(id)
+					if se_obj then
+						if ((amt - uses) == 0) then
+							stop = true
+						end
+						amt = amt - uses
+						alife_release(se_obj)
+					end
+				else
+					stop = true
+					local obj = get_object_by_id(id)
+					if obj then
+						obj:set_remaining_uses(uses - amt)
+					end
+				end
+			end
+		end
+	end
+	
+	-- Give cooked meal
+	alife_create_item(meal.sec, db.actor)
+	
+	-- Discharge multiuse cooking tools
+	if self.cooking_limited then
+		local item = nil
+		if self.multiUseItemsObj and self.multiUseItemsObj[1] then
+			for id, amount in pairs(self.multiUseItemsObj[1]) do
+				item = get_object_by_id(id)
+				-- attempt to fix spontaneous crashes
+				if amount == 1 and self.multiUseItemsObj[2] then
+					--printf("last amount, selecting next obj id")
+					for id2, amount2 in pairs(self.multiUseItemsObj[2]) do
+						self.obj = get_object_by_id(id2)
+					end
+				end
+			end
+		end
+		if (item) then
+			utils_item.discharge(item)
+		end
+	end
+
+	self.hasCraftedItem = true
+	if (self.last_cont and self.last_idx) then
+		--Dirty hack to update ui after alife item removal
+		--Disable cook button and enable again later in UI update
+		--to prevent item abusing and game borking
+		-- printf("Creating UpdateUI event")
+		self.btn_cook:Enable(false)
+		CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.UpdateUi, self)
+	end
+end
+
+item_cooking.UICook.Close = function(self)
+	-- Effect
+	if (self.hasCraftedItem and self.cooking_use_actor_effects and actor_effects) then
+		actor_effects.play_item_fx(self.section.."_dummy")
+	end
+
+	utils_obj.play_sound("interface\\inv_close")
+
+	self.hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.multiUseItemsObj = {}
+	self.multiUseItemsUses = 0
+	self.fuelCount = 0
+	
+	self:HideDialog()
+	
+	Unregister_UI("UICook")
+end

--- a/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_item_repair_keep_crafting_window_open.script
+++ b/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_item_repair_keep_crafting_window_open.script
@@ -1,0 +1,279 @@
+-- degrade_factor from item_repair file, local var there by default
+-- if that changes then it needs to be changed here also
+local degrade_factor = item_repair.degrade_factor or 0.2
+
+local IsItem = IsItem
+
+local InitControlsSuper = item_repair.UIRepair.InitControls
+item_repair.UIRepair.InitControls = function(self)
+	InitControlsSuper(self)
+	self.hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.cont_1_last_idx = 0
+	self.cont_2_last_idx = nil
+	self.isMultiUse = false
+	self.kitCondition = 1
+	self.multiUseItemsObj = {}
+	self.multiUseItemsUses = 0
+	self.partSection = nil
+	-- printf("calling override item_repair.InitControls")
+end
+
+item_repair.UIRepair.CollectValidItems = function(self, obj, section)
+	-- Collect valid items
+	empty_table(self.multiUseItemsObj)
+	local parts_id = {}
+	local is_multiuse = IsItem("multiuse", section, nil)
+	local function search(temp, item)
+		if (item:section() == section) and (not parts_id[item:id()]) then
+			local cnt = is_multiuse and item:get_remaining_uses() or 1
+			local id = item:id()
+			parts_id[id] = cnt
+			self.multiUseItemsObj[#self.multiUseItemsObj + 1] = {
+				[id]=cnt
+			}
+		end
+	end
+	db.actor:iterate_inventory(search,nil)
+	-- print_r(self.multiUseItemsObj)
+
+	-- Collect Uses
+	self.multiUseItemsUses = 0
+	for _,cnt in pairs(parts_id) do
+		self.multiUseItemsUses = self.multiUseItemsUses + cnt
+	end
+
+	-- check if item is multiuse and write either uses or condition
+	local uses
+	local color = ""
+	if (is_multiuse) then
+		self.condition = 1
+		self.isMultiUse = true
+		if self.multiUseItemsUses > 3 then
+			color = utils_xml.get_color("d_green")
+		elseif self.multiUseItemsUses > 2 then
+			color = utils_xml.get_color("pda_yellow")
+		elseif self.multiUseItemsUses > 1 then
+			color = utils_xml.get_color("d_orange")
+		else
+			color = utils_xml.get_color("d_red")
+		end
+		uses = self.multiUseItemsUses
+		-- printf("item %s is multiuse", section)
+	else
+		self.isMultiUse = false
+		self.condition = obj:condition()
+		if self.condition > degrade_factor * 2 then
+			color = utils_xml.get_color("d_green")
+		elseif self.condition > degrade_factor then
+			color = utils_xml.get_color("pda_yellow")
+		else
+			color = utils_xml.get_color("d_red")
+		end
+		uses = string.format("%s%%", math.ceil(self.condition * 100))
+		-- printf("item %s is not multiuse", section)
+	end
+
+	-- Write amount of uses near repair kit name
+	local str = color .. ui_item.get_sec_name(section) .. " (" .. uses .. ")"
+
+	self.cap_menu:SetText(str)
+
+	-- printf("Collecting Done")
+
+	return true
+end
+
+local ResetSuper = item_repair.UIRepair.Reset
+item_repair.UIRepair.Reset = function(self, obj, section)
+	ResetSuper(self, obj, section)
+	-- Set repair kit name, uses and icon, store uses
+	-- Delay because of alife shenanigans when using multiuse items with
+	-- heavy scripting like this
+	CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.CollectValidItems, self, obj, section)
+	--self:CollectValidItems(obj, section)
+	-- printf("Calling override Reset")
+	return true
+end
+
+local On_CC_Mouse1Super = item_repair.UIRepair.On_CC_Mouse1
+item_repair.UIRepair.On_CC_Mouse1 = function(self, cont, idx, keep_selection)
+	On_CC_Mouse1Super(self, cont, idx)
+
+	-- printf("calling override On_CC_Mouse1")
+
+	self.last_cont = cont
+	self.last_idx = idx
+	if (cont == 1) then
+		self.cont_1_last_idx = idx
+		self.cont_2_last_idx = nil
+		self.partSection = nil
+	elseif (cont == 2) then
+		-- disable selection on click on same part 
+		if (idx == self.cont_2_last_idx and not keep_selection) then
+			self:On_CC_Mouse1(1, self.cont_1_last_idx)
+			return true
+		end
+		-- store last bonus part selection and write its amount near the title
+		self.cont_2_last_idx = idx
+		local part_obj = self.CC[2]:GetObj(idx)
+		local part_sec = part_obj:section()
+		self.partSection = part_sec
+		local parts_id = {}
+		local part_count = 0
+		local is_part_multiuse = IsItem("multiuse", part_sec, nil)
+		local function search(temp, item)
+			if (item:section() == part_sec) and (not parts_id[item:id()]) then
+				local cnt = is_part_multiuse and item:get_remaining_uses() or 1
+				local id = item:id()
+				parts_id[id] = cnt
+				part_count = part_count + cnt
+			end
+		end
+		db.actor:iterate_inventory(search,nil)
+		if (part_sec == self.section) then
+			part_count = part_count - 1
+		end 
+		local color = ""
+		if part_count > 3 then
+			color = utils_xml.get_color("d_green")
+		elseif part_count > 2 then
+			color = utils_xml.get_color("pda_yellow")
+		elseif part_count > 1 then
+			color = utils_xml.get_color("d_orange")
+		else
+			color = utils_xml.get_color("d_red")
+		end
+		local name = ui_item.get_sec_name(part_sec)
+		self.text_item[2]:SetText(color .. name .. " (" .. part_count .. ")")
+	end
+
+	-- printf("last cont %s, last idx %s", self.last_cont, self.last_idx)
+	return true
+end
+
+item_repair.UIRepair.UpdateUi = function(self)
+	--printf("UpdateUI triggered")
+
+	-- close on last use or if condition is less than degrade_factor
+	-- otherwise script bork the game
+	-- considering repair kits than can use same section as a bonus part
+	-- printf("multiUseItemsUses: %s", self.multiUseItemsUses)
+	if ((self.isMultiUse and (self.multiUseItemsUses == 1 or (self.multiUseItemsUses == 2 and self.section == self.partSection))) or (not self.isMultiUse and self.condition <= degrade_factor)) then
+		self:OnCancel()
+		return true
+	end
+
+	self:InitInventory(1)
+	self:CollectValidItems(self.obj, self.section)
+	
+	-- if part was last in list and fully repaired, select previous one
+	-- otherwise select next one 
+	if (not self.CC[1]:GetObj(self.cont_1_last_idx)) then
+		self.cont_1_last_idx = self.cont_1_last_idx - 1
+	end
+	-- if last index is 0, so no part, close window
+	if (self.cont_1_last_idx <= 0) then
+		self:OnCancel()
+		return true
+	end
+	self.CC[1]:On_Select(self.cont_1_last_idx)
+
+	-- save bonus part selection if any
+	local cont_2_last_idx = nil
+	if (self.cont_2_last_idx) then
+		cont_2_last_idx = self.cont_2_last_idx
+	end
+
+	-- Update bonus part list
+	self:On_CC_Mouse1(1, self.cont_1_last_idx)
+
+	-- restore bonus part selection
+	self.cont_2_last_idx = cont_2_last_idx
+	if (self.cont_2_last_idx) then
+		if (not self.CC[2]:GetObj(self.cont_2_last_idx)) then
+			self.cont_2_last_idx = self.cont_2_last_idx - 1
+		end
+		if (self.cont_2_last_idx > 0 and self.CC[2]:GetObj(self.cont_2_last_idx)) then
+			self.CC[2]:On_Select(self.cont_2_last_idx)
+			self:On_CC_Mouse1(2, self.cont_2_last_idx, true)
+		end
+	end
+	return true
+end
+
+item_repair.UIRepair.OnRepair = function(self)
+	local obj_1 = self.CC[1]:GetCell_Selected(true)
+	local obj_2 = self.CC[2]:GetCell_Selected(true)
+	
+	if not (obj_1 and self.con_val[4]) then return end
+
+	obj_1:set_condition(self.con_val[4] / 100) -- Repair main item
+	if obj_2 then
+		utils_item.discharge(obj_2) -- Remove 1 use of the support item
+	end
+
+	self:CollectValidItems(self.obj, self.section)
+	
+	-- Remove 1 use of the combined repair kits
+	if self.isMultiUse then
+		local item = nil
+		if self.multiUseItemsObj and self.multiUseItemsObj[1] then
+			for id, amount in pairs(self.multiUseItemsObj[1]) do
+				item = get_object_by_id(id)
+				-- attempt to fix spontaneous crashes
+				if amount == 1 and self.multiUseItemsObj[2] then
+					--printf("last amount, selecting next obj id")
+					for id2, amount2 in pairs(self.multiUseItemsObj[2]) do
+						self.obj = get_object_by_id(id2)
+					end
+				end
+			end
+		end
+		if (item) then
+			utils_item.discharge(item)
+		end
+	else
+		utils_item.degrade(self.obj, degrade_factor)
+	end
+	
+	self.hasCraftedItem = true
+	
+	-- Increase Statistic
+	game_statistics.increment_statistic("self_repairs")
+
+	utils_obj.play_sound("interface\\inv_properties_2")
+
+	if (self.last_cont and self.last_idx) then
+		--Dirty hack to update ui after alife item removal
+		--Disable repair button and enable again later in UI update
+		--to prevent item abusing and game borking
+		--printf("Creating UpdateUI event")
+		self.btn_repair:Enable(false)
+		CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.UpdateUi, self)
+	end
+	
+end
+
+item_repair.UIRepair.OnCancel = function(self)
+	-- Effect
+	if (self.hasCraftedItem and self.use_actor_effects and actor_effects) then
+		actor_effects.play_item_fx(self.section.."_dummy")
+	end
+
+	utils_obj.play_sound("interface\\inv_close")
+
+	self.hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.cont_1_last_idx = 0
+	self.cont_2_last_idx = nil
+	self.multiUseItemsObj = {}
+	self.multiUseItemsUses = 0
+	self.partSection = nil
+	
+	self:HideDialog()
+	
+	Unregister_UI("UIRepair")
+end

--- a/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_ui_workshop_keep_crafting_window_open.script
+++ b/G.A.M.M.A/modpack_addons/143- Keep Crafting Window Opened - Demonized/gamedata/scripts/zz_ui_workshop_keep_crafting_window_open.script
@@ -1,0 +1,303 @@
+local SetTip = ui_workshop.SetTip
+local AdjustCon = ui_workshop.AdjustCon
+local print_ws = ui_workshop.print_ws
+
+local IsItem = IsItem
+local IsWeapon = IsWeapon
+
+local hasCraftedItem = false
+
+local CraftInitControlsSuper = ui_workshop.UIWorkshopCraft.InitControls
+ui_workshop.UIWorkshopCraft.InitControls = function(self, x, y)
+	CraftInitControlsSuper(self, x, y)
+	self.last_cont = nil
+	self.last_idx = nil
+	--printf("calling override InitControls")
+end
+
+local CraftOn_CC_Mouse1_Super = ui_workshop.UIWorkshopCraft.On_CC_Mouse1
+ui_workshop.UIWorkshopCraft.On_CC_Mouse1 = function(self, cont, idx)
+	CraftOn_CC_Mouse1_Super(self, cont, idx)
+	self.last_cont = cont
+	self.last_idx = idx
+	--printf("calling override On_CC_Mouse1")
+	return true
+end
+
+ui_workshop.UIWorkshopCraft.UpdateUi = function(self, cont, idx)
+	self:ListItems()
+	self:On_CC_Mouse1(cont, idx)
+	--return true needed for CreateTimeEvent function to queue update once
+	return true
+end
+
+ui_workshop.UIWorkshopCraft.Close = function(self)
+	-- Effect
+	if (hasCraftedItem) then
+		actor_effects.play_item_fx("craft_dummy")
+	end
+
+	--printf("calling override Close")
+
+	hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.owner:Close()
+end
+
+ui_workshop.UIWorkshopCraft.Craft = function(self)
+	if (not self.craft_allow_r) then 
+		return 
+	end
+
+	--printf("calling override Craft")
+	
+	-- Remove supportive items
+	for i=1,#self.craft_item do
+		-- Release
+		if #self.craft_item[i] > 0 then
+			for j=1,#self.craft_item[i] do
+				alife_release_id(self.craft_item[i][j])
+			end
+		end
+		
+		-- Discharge
+		local id_r = self.craft_item_remain[i].id
+		if id_r then
+			local obj_itm = get_object_by_id(id_r)
+			local cnt = self.craft_item_remain[i].cnt
+			if obj_itm and cnt then
+				print_ws("- UIWorkshopCraft:Craft() | discharge item (%s) [%s] %s times", id_r, obj_itm:section(), cnt)
+				for k=1,cnt do
+					utils_item.discharge(obj_itm)
+				end
+			end
+		end
+	end
+	
+	-- Craft
+	if IsItem("ammo",self.craft_item_r[1]) then
+		alife_create_item(self.craft_item_r[1], db.actor, {ammo = self.craft_item_r[2]})
+	else
+		for i = 1, self.craft_item_r[2] do
+			alife_create_item(self.craft_item_r[1], db.actor)
+		end
+	end
+	
+	-- Increase Statistic
+	game_statistics.increment_statistic("items_crafted")
+	
+	hasCraftedItem = true
+	if (self.last_cont and self.last_idx) then
+		--Dirty hack to update ui after alife item removal
+		--Disable button and reenable later in update event
+		self.btn_craft:Enable(false)
+		CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.UpdateUi, self, self.last_cont, self.last_idx)
+	end
+end
+
+local RepairInitControlsSuper = ui_workshop.UIWorkshopRepair.InitControls
+ui_workshop.UIWorkshopRepair.InitControls = function(self, x, y)
+	RepairInitControlsSuper(self, x, y)
+	self.last_cont = nil
+	self.last_idx = nil
+	--printf("calling override InitControls")
+end
+
+local RepairOn_CC_Mouse1_Super = ui_workshop.UIWorkshopRepair.On_CC_Mouse1
+ui_workshop.UIWorkshopRepair.On_CC_Mouse1 = function(self, cont, idx)
+	RepairOn_CC_Mouse1_Super(self, cont, idx)
+	self.last_cont = cont
+	self.last_idx = idx
+	--printf("calling override On_CC_Mouse1")
+	return true
+end
+
+ui_workshop.UIWorkshopRepair.UpdateUi = function(self, cont, idx)
+	self:Reset()
+	--self:On_CC_Mouse1(cont, idx)
+	--return true needed for CreateTimeEvent function to queue update once
+	return true
+end
+
+ui_workshop.UIWorkshopRepair.Close = function(self)
+	-- Effect
+	if (hasCraftedItem) then
+		actor_effects.play_item_fx("craft_dummy")
+	end
+
+	--printf("calling override Close")
+
+	hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.owner:Close()
+end
+
+ui_workshop.UIWorkshopRepair.Repair = function(self)
+	local obj = self.CC["inventory"]:GetCell_Selected(true)
+	if (not obj) then
+		return
+	end
+	
+	local sim = alife()
+	local tot_con = 0
+	local cnt = 0
+	if is_not_empty(self.new_con) then
+		for i=1,6 do
+			if self.parts[i] and self.parts[i].sec and (self.parts[i].sec ~= "na") then
+				if self.new_con[i] and self.new_con[i].id then
+					self.parts[i].con = self.new_con[i].con
+					print_ws("- UIWorkshopRepair:Repair() | replaced part spotted | part: %s - condition: %s - order: %s - id: %s", self.parts[i].sec, self.new_con[i].con, i, self.new_con[i].id)
+					
+					-- Release replacement parts
+					alife_release_id(self.new_con[i].id)
+				end
+				
+				tot_con = tot_con + self.parts[i].con --AdjustCon(self.parts[i].sec, self.parts[i].con, #self.parts, IsOutfit(self.object))
+				cnt = cnt + 1
+				print_ws("/ UIWorkshopRepair:Repair() | total condition calculation | part: %s - condition: %s - order: %s - total sum: %s", self.parts[i].sec, self.parts[i].con, i, tot_con)
+			end
+		end
+	else
+		print_ws("! UIWorkshopRepair:Repair() | no new parts have been replaced")
+		return
+	end
+	
+	-- Discharge tools
+	for i=1,#self.toolkit_pick do
+		local obj_tool = level.object_by_id(self.toolkit_pick[i])
+		if obj_tool then
+			utils_item.discharge(obj_tool)
+			print_ws("/ UIWorkshopRepair:Repair() | discharged toolkit (%s)", self.toolkit_pick[i])
+		else
+			printe("!ERROR UIWorkshopRepair:Repair() | can't discharge toolkit with id (%s). Object not found!", self.toolkit_pick[i])
+		end
+	end
+	
+	-- Apply condition changes
+	local id = obj:id()
+	local sec = obj:section()
+	sec = ini_sys:r_string_ex(sec,"parent_section") or sec -- for weapons with scopes
+	
+	local final_con = (cnt > 0) and (clamp(math.ceil(tot_con/cnt),1,100)/100)
+	local weapon = level.object_by_id(id)
+	if weapon and final_con and (final_con >= 0) and (final_con <= 1) then
+		weapon:set_condition(final_con)
+		print_ws("- UIWorkshopRepair:Repair() | object with id (%s) is set to a new condition: %s", id, final_con)
+	else
+		printe("! UIWorkshopRepair:Repair() | object with id (%s) is either not found. Or didn't register new condition (%s)!", id, final_con)
+	end
+	
+	local result_part_tbl = {}
+	result_part_tbl[sec] = math.ceil(tot_con/cnt)
+	for i=1,#self.parts do
+		result_part_tbl[self.parts[i].sec] = self.parts[i].con
+	end
+	item_parts.set_parts_con(id, result_part_tbl)
+	
+	for k,v in pairs(result_part_tbl) do
+		print_ws("~ UIWorkshopRepair:Repair() | item's new part table [%s] = %s",k,v)
+	end
+
+	utils_obj.play_sound("interface\\inv_properties_2")
+	
+	hasCraftedItem = true
+	if (self.last_cont and self.last_idx) then
+		--Dirty hack to update ui after alife item removal
+		--Disable button and reenable later in update event
+		self.btn_repair:Enable(false)
+		CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.UpdateUi, self, self.last_cont, self.last_idx)
+	end
+end
+
+local UpgradeInitControlsSuper = ui_workshop.UIWorkshopUpgrade.InitControls
+ui_workshop.UIWorkshopUpgrade.InitControls = function(self, x, y)
+	UpgradeInitControlsSuper(self, x, y)
+	self.last_cont = nil
+	self.last_idx = nil
+	--printf("calling override InitControls")
+end
+
+local UpgradeOn_CC_Mouse1_Super = ui_workshop.UIWorkshopUpgrade.On_CC_Mouse1
+ui_workshop.UIWorkshopUpgrade.On_CC_Mouse1 = function(self, cont, idx)
+	UpgradeOn_CC_Mouse1_Super(self, cont, idx)
+	self.last_cont = cont
+	self.last_idx = idx
+	--printf("calling override On_CC_Mouse1")
+	return true
+end
+
+ui_workshop.UIWorkshopUpgrade.UpdateUi = function(self, cont, idx)
+	self:Reset()
+	--self:On_CC_Mouse1(cont, idx)
+	--return true needed for CreateTimeEvent function to queue update once
+	return true
+end
+
+ui_workshop.UIWorkshopUpgrade.Close = function(self)
+	-- Effect
+	if self.owner.dbg then
+	
+	elseif hasCraftedItem then
+		actor_effects.play_item_fx("craft_dummy")
+	end
+
+	--printf("calling override Close")
+
+	hasCraftedItem = false
+	self.last_cont = nil
+	self.last_idx = nil
+	self.owner:Close()
+end
+
+ui_workshop.UIWorkshopUpgrade.Upgrade = function(self)
+	local obj = self.CC:GetCell_Selected(true)
+	if (not obj) then
+		return
+	end
+	
+	-- For weapons, unload mag and clear ammo cache in case of ammo type upgrades
+	if IsWeapon(obj) and (not IsItem("fake_ammo_wpn",obj:section())) then
+		obj:force_unload_magazine(true)
+		item_weapon.clear_cache(obj)
+	end
+	
+	-- Sort upgrades
+	k2t_table(self.inst_upgr)
+	local sort_tbl = {}
+	for i=1,#self.upgr_order do
+		for ii=1,#self.inst_upgr do
+			if string.find(self.inst_upgr[ii],self.upgr_order[i]) then
+				sort_tbl[#sort_tbl+1] = self.inst_upgr[ii]
+				break
+			end
+		end
+	end
+	
+	-- Install upgrades
+	inventory_upgrades.force_upgrade = true
+	for i=1,#sort_tbl do
+		--printf("installing: %s - for [%s]", sort_tbl[i], obj:name())
+		obj:install_upgrade(sort_tbl[i])
+	end
+	inventory_upgrades.force_upgrade = false
+
+	-- Discharge tools
+	for i=1,#self.upgr_tools_pick do
+		local t_obj = level.object_by_id(self.upgr_tools_pick[i])
+		if t_obj then
+			utils_item.discharge(t_obj)
+		end
+	end
+
+	utils_obj.play_sound("interface\\inv_properties_2")
+		
+	hasCraftedItem = true
+	if (self.last_cont and self.last_idx) then
+		--Dirty hack to update ui after alife item removal
+		--Disable button and reenable later in update event
+		self.btn_upgrade:Enable(false)
+		CreateTimeEvent("totally_not_random_event" .. random_number(1, 1000000), "update_ui_delay" .. random_number(1, 1000000), 0.1, self.UpdateUi, self, self.last_cont, self.last_idx)
+	end
+end


### PR DESCRIPTION
GAMMA didn't patch this mod before, so all 3 files show up as new. Actual diffs vs upstream are small.

### zz_item_cooking_keep_crafting_window_open.script

- (crash) :253 nil-guard the `pairs(self.multiUseItemsObj[1])` loop in `OnCook`. After `CollectValidItems` clears and refills the table, `[1]` can be nil when the actor has no items of `self.section`. `pairs(nil)` CTDs. Guarded path skips the tool discharge. The original author's `-- attempt to fix spontaneous crashes` comment already acknowledges this failure mode without a fix.
- (micro-perf) :23 pull `IsItem("multiuse", section, nil)` out of the `iterate_inventory` closure in `CollectValidItems`. `section` is constant per call. One call instead of one per inventory item.
- (micro-perf) :5 cache `local IsItem = IsItem`.

### zz_item_repair_keep_crafting_window_open.script

- (crash) :222 same nil-guard at `OnRepair`. Trigger: a multi-use repair kit at last charge selected as its own bonus part. `utils_item.discharge(obj_2)` releases it, `CollectValidItems(self.obj, self.section)` finds nothing, `multiUseItemsObj[1]` is nil.
- (micro-perf) :27 pull `IsItem("multiuse", section, nil)` out of `CollectValidItems`. The same value is reused at :50 in place of a second `IsItem` call.
- (micro-perf) :125 pull `IsItem("multiuse", part_sec, nil)` out of `On_CC_Mouse1` cont==2 (bonus-part display refresh). Named `is_part_multiuse` to keep it distinct from the outer `is_multiuse`.
- (micro-perf) :5 cache `local IsItem = IsItem`.

### zz_ui_workshop_keep_crafting_window_open.script

- (micro-perf) :5, :6 cache `local IsItem = IsItem` and `local IsWeapon = IsWeapon`. Used in `UIWorkshopCraft.Craft` (:79 `IsItem("ammo", self.craft_item_r[1])`) and `UIWorkshopUpgrade.Upgrade` (:261 `IsWeapon(obj)`, `IsItem("fake_ammo_wpn", obj:section())`).

### Notes

- The two original-author comments (`-- attempt to fix spontaneous crashes`, `--printf("last amount, selecting next obj id")`) stay inside the guarded block.
- `IsItem` and `IsWeapon` are safe to cache as locals: no mod rebinds them. The four timer globals (`CreateTimeEvent`, `RemoveTimeEvent`, `ResetTimeEvent`, `ProcessEventQueue`) get rebound at load time by `demonized_time_events.script`, and the mod already calls those bare at runtime.
- Tested in-game: both crash paths reproduce on upstream. The overlay clears them.
