### PR TITLE
_g_patches: shuffle_table nil guard

### DIFF
--- a/G.A.M.M.A/modpack_patches/gamedata/scripts/_g_patches.script
+++ b/G.A.M.M.A/modpack_patches/gamedata/scripts/_g_patches.script
@@ -1119,6 +1119,7 @@ end
 
 -- Shuffle table, Fisher-Yates shuffle
 _G.shuffle_table = function(t)
+   if type(t) ~= "table" then return end
    for i = #t, 2, -1 do
         local j = math_random(i)
         t[i], t[j] = t[j], t[i]


### PR DESCRIPTION
`shuffle_table` at `_g_patches.script:1121` reads `#t` with no type check.
Passing a non-table crashes the engine with `attempt to get length of a nil value` and ends the session.

Source of the nil in GAMMA 0.9.5:

`G.A.M.M.A. Rare Stashes Balance / treasure_manager.script` defines two level-keyed tables at lines 56 (`map_tiers`) and 92 (`tools_map_tiers`), each listing tier vectors for about 33 named levels.
Function `set_random_stash` (line 477) reads them without guard:

- line 533: `local map_tier_vector = map_tiers[lvl]`
- line 657: `local tools_map_tier_vector = tools_map_tiers[lvl]`

When `set_random_stash` runs for a stash on a level not in those tables (a level the mod author did not list, including mod-added levels), the local becomes nil and feeds into `shuffle_table` at lines 549, 560, 658.
CTD.

`set_random_stash` runs whenever stash content is rolled.
Typical trigger: first reveal of a stash via the standard Anomaly stash-discovery flow (`create_random_stash` at line 365 is the entry point).

Other places the same crash shape can fire:

`shuffle_table` is called from 28 sites across base Anomaly and GAMMA addons.
Any call of the form `shuffle_table(table[key])` where `key` is not guaranteed to be in `table` will crash on a miss.
Base Anomaly examples:

- `death_manager.script:70, 279, 849`: `shuffle_table(item_by_community[x])`, loot rolls on death
- `xrs_rnd_npc_loadout.script:127, 260`: `shuffle_table(loadouts[slot])`, NPC loadout rolls
- `bind_anomaly_zone.script:366`: `shuffle_table(t_layer)`, anomaly layer init
- `sim_offline_combat.script:115`: `shuffle_table(tbl_smart)`, offline combat

A callee-side guard catches all of these, present and future.
The unguarded lookups at `treasure_manager.script:533, :657` are a separate concern.
The real fix is in the caller (skip stash, fall back to a default tier) but the choice is gameplay-side, not crash-side.