### PR TITLE
Stealth Overhaul: lights_lum cache, camp_lum cleanup, light_gem fixes

### DIFF
--- a/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/camp_lum.script
+++ b/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/camp_lum.script
@@ -1,33 +1,37 @@
 -- Feel_Fried
 
 luminocity_inc = 0
+
 function on_game_start()
-RegisterScriptCallback("actor_on_first_update",actor_on_first_update)
+    RegisterScriptCallback("actor_on_first_update", actor_on_first_update)
+    RegisterScriptCallback("actor_on_net_destroy", actor_on_net_destroy)
 end
 
 function actor_on_first_update()
-CreateTimeEvent(0, "campfire_reculc", (0.5), campfire_reculc)
+    RemoveTimeEvent(0, "campfire_reculc")
+    RemoveTimeEvent(0, "campfire_reculc2")
+    CreateTimeEvent(0, "campfire_reculc", 0.5, campfire_reculc)
+end
+
+function actor_on_net_destroy()
+    RemoveTimeEvent(0, "campfire_reculc")
+    RemoveTimeEvent(0, "campfire_reculc2")
 end
 
 function campfire_reculc()
-		--printf("camp reculc")
-		local camp_8 = bind_campfire.get_nearby_campfire(53, true)
-        local camp_6 = bind_campfire.get_nearby_campfire(42, true)
-     --   local camp_4 = bind_campfire.get_nearby_campfire(14, true)
-     --   if (camp_4 and camp_4:is_on()) then
-           -- luminocity_inc = 0.55
-        if (camp_6 and camp_6:is_on()) then
-            luminocity_inc  = 0.45
-        elseif (camp_8 and camp_8:is_on()) then
-            luminocity_inc = 0.15
-		else 
-		luminocity_inc = 0
-        end 
-		CreateTimeEvent(0, "campfire_reculc2", (0.01), campfire_reculc2)
-return true
-end
+    ResetTimeEvent(0, "campfire_reculc", 0.5)
 
-function campfire_reculc2()
-CreateTimeEvent(0, "campfire_reculc", (0.5), campfire_reculc)
-return true
+    local camp_6 = bind_campfire.get_nearby_campfire(42, true)
+    if camp_6 and camp_6:is_on() then
+        luminocity_inc = 0.45
+        return
+    end
+
+    local camp_8 = bind_campfire.get_nearby_campfire(53, true)
+    if camp_8 and camp_8:is_on() then
+        luminocity_inc = 0.15
+        return
+    end
+
+    luminocity_inc = 0
 end

--- a/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/light_gem_mcm.script
+++ b/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/light_gem_mcm.script
@@ -9,15 +9,28 @@ FLASHLIGHT_PENALTY = .3 --flat value to make the gem jump as a reminder that you
 
 GEM_ON = false
 
+local gem
+local last_update = 0
+local update_interval = 100
 
-function on_game_start()
-	RegisterScriptCallback("actor_on_update",light_gem)
+function actor_on_net_destroy()
+	local hud = get_hud()
+	if not hud then return end
+	local cs = hud:GetCustomStatic("mp_warm_up")
+	if cs then hud:RemoveCustomStatic("mp_warm_up") end
+	gem = nil
 end
 
-
-local gem
+function on_game_start()
+	RegisterScriptCallback("actor_on_update", light_gem)
+	RegisterScriptCallback("actor_on_net_destroy", actor_on_net_destroy)
+end
 
 function light_gem()
+	local now = time_global()
+	if now - last_update < update_interval then return end
+	last_update = now
+
 	local hud = get_hud()
 	local cs = hud:GetCustomStatic("mp_warm_up") 
 		if (cs == nil) then 

--- a/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/visual_memory_manager.script
+++ b/G.A.M.M.A/modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/visual_memory_manager.script
@@ -198,12 +198,23 @@ function andruxa(animegif)
 	return 0.21 * animegif.x + 0.72 * animegif.y + 0.07 * animegif.z
 end
 
+local cached_lights_lum = 0
+local lights_lum_cache_time = 0
+local lights_lum_cache_interval = 100
+
 function lights_lum(andre)
+	local now = time_global()
+	if now - lights_lum_cache_time < lights_lum_cache_interval then
+		return cached_lights_lum
+	end
+	lights_lum_cache_time = now
+
 	local andlum = andre
 	local andsun =  andruxa(weather.get_value_vector("sun_color"))
 	local andhem = andruxa(weather.get_value_vector("hemisphere_color"))
 	andlum = (math.max(andhem, andsun))
 
+	cached_lights_lum = andlum
 	return andlum
 end
 


### PR DESCRIPTION
Three fixes in `45- Stealth Overhaul - xcvb` at `modpack_addons/45- Stealth Overhaul - xcvb/gamedata/scripts/`.

## visual_memory_manager.script: 100ms cache on lights_lum()

`lights_lum()` is called from `get_visible_value` (line 38), invoked by the engine per NPC visibility check. With 50 NPCs at 60fps that is ~3000 calls/sec, each doing two `weather.get_value_vector` luabind calls. The values it reads (sun_color, hemisphere_color) are interpolated over multi-second timescales by the weather manager. 100ms cache is invisible at that rate.

The `andre` parameter is dead in the original: assigned to `andlum`, then immediately overwritten by `andlum = math.max(andhem, andsun)`. All three callers pass no args. Cache ignores it, preserving original behavior.

## camp_lum.script: timer chain cleanup

`campfire_reculc` schedules `campfire_reculc2`, which schedules `campfire_reculc` again. A 510ms ping-pong with two distinct keys. `actor_on_first_update` re-creates the chain on every level change. `CreateTimeEvent` dedups by `(ev_id, act_id)`, but the two distinct keys let the new chain interleave with the in-flight one for a cycle.

Separately: between `actor_on_net_destroy` (level exit) and the next `actor_on_first_update`, a pending `campfire_reculc` fire would call `bind_campfire.get_nearby_campfire`, which does `db.actor:position()` on nil and crashes.

Rewrite:
- `actor_on_first_update` and `actor_on_net_destroy` both `RemoveTimeEvent` the chain.
- `campfire_reculc` calls `ResetTimeEvent` on itself to re-arm at 0.5s. Single key. No `campfire_reculc2`.
- Closer-fire-first early returns: `camp_6` (42 squared, brighter 0.45) first; skip the 53 scan when that wins.

## light_gem_mcm.script: throttle + actor_on_net_destroy cleanup

`light_gem` was registered on `actor_on_update` and ran every frame to update the stealth-indicator HUD widget. The throttle caps it at one update per 100ms (10Hz). Widget is HUD-only: no AI vision reads `light_gem_mcm.*` or the gem state (grep across base Anomaly and GAMMA mods returned zero AI consumers).

`actor_on_net_destroy` removes the `mp_warm_up` CustomStatic on actor unload. `local gem` declaration moved above the cleanup so `gem = nil` clears the local instead of the file's namespace table.