### PR TITLE
Global weapon trade blacklist

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Difficulty Presets Rebalance/gamedata/configs/plugins/difficulty.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Difficulty Presets Rebalance/gamedata/configs/plugins/difficulty.ltx
@@ -41,6 +41,7 @@
 
 
 [econ_1]
+condition_buy_override          = 0.01
 goodwill					    = 1.4
 rewards							= 1.25
 repair					        = 1.0
@@ -64,6 +65,7 @@ outfit_drops                    = 2
 
 
 [econ_2]
+condition_buy_override          = 0.01
 goodwill					    = 1.2
 rewards							= 1.1
 repair					        = 1.3
@@ -87,6 +89,7 @@ outfit_drops                    = 2
 
 
 [econ_3]
+condition_buy_override          = 0.01
 goodwill					    = 1.0
 rewards							= 0.9
 repair					        = 1.7

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/grok_gun_condition_fixed.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/grok_gun_condition_fixed.script
@@ -49,6 +49,7 @@ function on_game_start()
 	RegisterScriptCallback("actor_on_weapon_fired", set_weapon_fire_condition)
 	RegisterScriptCallback("actor_on_item_take", set_weapon_condition)
 	RegisterScriptCallback("actor_item_to_ruck", set_weapon_condition)
+	RegisterScriptCallback("actor_item_to_slot", set_weapon_condition)
 	RegisterScriptCallback("ActorMenu_on_mode_changed", ActorMenu_on_mode_changed)
 	RegisterScriptCallback("GUI_on_hide", GUI_on_hide)
 end

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/grok_gun_condition_fixed.script
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Guns Have No Condition/gamedata/scripts/grok_gun_condition_fixed.script
@@ -17,8 +17,38 @@ function set_weapon_condition(item)
 	end
 end
 
+local flag = false
+function ActorMenu_on_mode_changed(mode)
+	-- trade
+	if mode == 2 then
+		db.actor:iterate_inventory(blacklist_all_weapon_trade)
+	end
+end
+
+function GUI_on_hide()
+	if flag == true then
+		db.actor:iterate_inventory(set_all_weapon_condition)
+	end
+end
+
+function blacklist_all_weapon_trade(_, item)
+	if item and IsWeapon(item) and not IsMelee(item) then
+		item:set_condition(0.001)
+		flag = true
+	end
+end
+
+function set_all_weapon_condition(_, item)
+	if item and IsWeapon(item) and not IsMelee(item) then
+		item:set_condition(cond)
+		flag = false
+	end
+end
+
 function on_game_start()
 	RegisterScriptCallback("actor_on_weapon_fired", set_weapon_fire_condition)
 	RegisterScriptCallback("actor_on_item_take", set_weapon_condition)
 	RegisterScriptCallback("actor_item_to_ruck", set_weapon_condition)
+	RegisterScriptCallback("ActorMenu_on_mode_changed", ActorMenu_on_mode_changed)
+	RegisterScriptCallback("GUI_on_hide", GUI_on_hide)
 end


### PR DESCRIPTION
Temporarily sets weapon condition below threshold during trading.
Changing minimal trade condition doesn't seem to affect anything since Parts Handler donates 0% parts.

Also added extra condition reset callback just in case.