### PR TITLE
Damien's Bolt Fix: bolts on the ground when NPCs spawn

### DIFF
--- a/G.A.M.M.A/modpack_addons/Damien's Bolt Fix/gamedata/configs/items/weapons/m_bolt.ltx
+++ b/G.A.M.M.A/modpack_addons/Damien's Bolt Fix/gamedata/configs/items/weapons/m_bolt.ltx
@@ -22,7 +22,7 @@
         inv_name_short              = st_bolty
         description                 = st_bolty_descr
         
-        kind                        = w_misc
+        kind                        = w_mbolt
         inv_weight                  = 0.01
         cost                        = 10
         


### PR DESCRIPTION
### Bug

A bolt drops on the ground whenever an NPC spawns or comes online. F7 spawns and natural simulation both trigger it. Some of the dropped bolts can't be picked up.

### Cause

`m_bolt.ltx` ships `kind = w_misc` inherited from vanilla Anomaly. The rest of the GAMMA stack uses `kind = w_mbolt`: `166- New sorting tabs - Bartoche` introduced it for sort tab #6, and both `G.A.M.M.A. UI` and `98- Better Bolt Animations` match. Damien's mod outranks all three in modlist priority, so its `m_bolt.ltx` wins the conflict and bolts get the wrong kind in-game.

### m_bolt.ltx

- (fix) :25 `kind = w_mbolt`. HUD animations (`bolt_sh.omf` 3-phase throw, `[bolt_hud]` hand position) unchanged.

### Test

- Vanilla Anomaly, no GAMMA: 300 F7-spawned NPCs, zero ground bolts.
- Full GAMMA, original `w_misc`: ground bolts on every spawn cycle.
- Full GAMMA, `w_mbolt` patch: hundreds of spawns across reloads, zero ground bolts.