### PR TITLE
Fix MAC-18 missing from magazines system

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_mac10_mac18.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Weapon Pack/gamedata/configs/magazines/weapons/w_mac10_mac18.ltx
@@ -1,0 +1,18 @@
+; Magazine lookup fix for the G.A.M.M.A. Weapon Pack's MAC-18 conversion.
+;
+; The Weapon Pack converts wpn_mac10 from 9x19 (MAC-10) to 9x18 (MAC-18) via
+; mod_system_zzzzz_gamma_mac18.ltx, and its base_mac10.ltx rewrites the
+; [mac10_9x19] base type's caliber from 9x19 to 9x18 to match.
+;
+; However the weapon-magazine lookup (originally from 487- MAC10 Quality Control)
+; still only maps ammo_9x19_fmj to the mac10_9x19 base type. With the gun now
+; firing 9x18, there is no base_type binding for its actual ammo and the
+; magazine system skips the gun entirely.
+;
+; This file merges the missing 9x18 mapping into the existing [wpn_mac10] entry.
+; Filename starts with "w_mac10_" so it loads alphabetically after the upstream
+; w_mac10.ltx, ensuring the !-override targets a section that already exists.
+
+![wpn_mac10]
+;base_type for the MAC-18 (9x18) conversion
+ammo_9x18_fmj = mac10_9x19


### PR DESCRIPTION
The Weapon Pack converts wpn_mac10 from 9x19 (MAC-10) to 9x18 (MAC-18) via mod_system_zzzzz_gamma_mac18.ltx, and its base_mac10.ltx rewrites the [mac10_9x19] base type's caliber from 9x19 to 9x18 to match. However the upstream weapon-magazine lookup (from 487- MAC10 Quality Control) only maps ammo_9x19_fmj -> mac10_9x19, so after the conversion the gun has no base_type binding for its actual ammo and the magazine system silently skips it.

Adds w_mac10_mac18.ltx with a DLTX merge override (![wpn_mac10]) supplying the missing ammo_9x18_fmj mapping. Non-destructive: the existing 9x19 and 11.43x23 mappings from the upstream lookup are preserved. Filename sorts alphabetically after the upstream w_mac10.ltx so the override targets a section that already exists.