### PR TITLE
Fix for #749: Added a nil sanity check to _G.hspairs before the call to pairs

### DIFF
--- a/G.A.M.M.A/modpack_patches/gamedata/scripts/_g_patches.script
+++ b/G.A.M.M.A/modpack_patches/gamedata/scripts/_g_patches.script
@@ -803,6 +803,7 @@ _G.hspairs = function(t, order)
     -- collect the keys
     local n = 0
     local keys = {}
+    if t == nil then return nil_func end
     for k in pairs(t) do
     	n = n + 1
         keys[n] = k


### PR DESCRIPTION
I made this change to fix #749, but wanted to submit it. It seems that _g_patches.script is sort of a core script, and many others rely upon it. If a similar condition would exist elsewhere, it may help with that, as well. I also note that it may be an incomplete fix, but I can't really tell on my own. Lua is not my strong suit. However, it's a one-liner, and so far works beautifully. I disassembled 60 PBs very quickly with no issues and no drop in performance. I can't foresee any negative effects of adding this quick sanity check to make sure we're not gonna crash.
