### PR TITLE
More common base R700

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_csky.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_csky.ltx
@@ -152,8 +152,8 @@ wpn_mp133:0:3:5
 wpn_k98:0:0:15
 wpn_k98_mod:0:0:25
 wpn_steyr_scout_big:0:0:15
-wpn_remington700:0:0:5
-wpn_remington700_magpul_pro:0:0:15
+wpn_remington700:0:0:15
+wpn_remington700_magpul_pro:0:0:10
 
 ;- RIFLE
 wpn_winchester1873:0:0:5

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_ecolog.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_ecolog.ltx
@@ -97,8 +97,8 @@ wpn_spas12:r:3:20
 ;- SNIPER
 wpn_k98_mod:0:0:15
 wpn_steyr_scout_big:0:0:15
-wpn_remington700:0:0:15
-wpn_remington700_magpul_pro:0:0:30
+wpn_remington700:0:0:30
+wpn_remington700_magpul_pro:0:0:15
 wpn_l96a1m:r:0:5
 wpn_m98b:r:0:3
 

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_freedom.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_freedom.ltx
@@ -82,7 +82,7 @@ wpn_spas12:r:3:10
 wpn_k98:0:0:5
 wpn_k98_mod:0:0:15
 wpn_steyr_scout_big:0:0:15
-wpn_remington700:0:0:15
+wpn_remington700:0:0:20
 wpn_remington700_magpul_pro:0:0:15
 
 ;- RIFLE
@@ -147,7 +147,7 @@ wpn_benelli_m1014:r:6:20
 wpn_k98:0:3:5
 wpn_k98_mod:0:3:15
 wpn_steyr_scout_big:0:3:15
-wpn_remington700:0:3:15
+wpn_remington700:0:3:20
 wpn_remington700_magpul_pro:0:3:15
 wpn_l96a1m:r:0:5
 wpn_m98b:r:0:3

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_killer.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Loadouts/gamedata/configs/items/settings/npc_loadouts/npc_loadouts_killer.ltx
@@ -104,8 +104,8 @@ wpn_mp133:0:3:5
 ;- SNIPER
 wpn_k98_mod:0:0:15
 wpn_steyr_scout_big:0:0:15
-wpn_remington700:0:0:15
-wpn_remington700_magpul_pro:0:0:30
+wpn_remington700:0:0:30
+wpn_remington700_magpul_pro:0:0:15
 wpn_l96a1m:r:0:5
 wpn_m98b:r:0:3
 
@@ -168,7 +168,7 @@ wpn_saiga12s_isg:4:6:5
 ;- SNIPER
 wpn_steyr_scout_big:r:3:15
 wpn_remington700:r:3:15
-wpn_remington700_magpul_pro:r:3:15
+wpn_remington700_magpul_pro:r:3:10
 wpn_l96a1m:r:0:25
 wpn_m98b:r:0:15
 wpn_remington700_lapua700:r:0:25


### PR DESCRIPTION
Made R700 base version more common across lower ranks, and magpull less common to allow the ability for players to buy and use the other kits for the base r700. magpull is just too common as is.