### PR TITLE
G.A.M.M.A. NPC Spawns: fix crash on invalid killer_sim_squad_advanced spawn section

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_b32.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_b32.ltx
@@ -12,5 +12,5 @@ spawn_stalker_c
 
 
 [spawn_stalker_c]
-spawn_squads = ecolog_sim_squad_advanced, killer_sim_squad_advanced, greh_sim_squad_alpha, monolith_sim_squad_alpha, renegade_sim_squad_alpha
+spawn_squads = ecolog_sim_squad_advanced, merc_sim_squad_advanced, greh_sim_squad_alpha, monolith_sim_squad_alpha, renegade_sim_squad_alpha
 spawn_num = {+living_legend_psy_helmet} 2, 0

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_b46.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_b46.ltx
@@ -12,5 +12,5 @@ spawn_stalker_c
 
 
 [spawn_stalker_c]
-spawn_squads = stalker_sim_squad_advanced, killer_sim_squad_advanced, freedom_sim_squad_advanced, zombied_sim_squad_novice, zombied_sim_squad_advanced, zombied_sim_squad_veteran, greh_sim_squad_veteran, monolith_sim_squad_veteran
+spawn_squads = stalker_sim_squad_advanced, merc_sim_squad_advanced, freedom_sim_squad_advanced, zombied_sim_squad_novice, zombied_sim_squad_advanced, zombied_sim_squad_veteran, greh_sim_squad_veteran, monolith_sim_squad_veteran
 spawn_num = {+living_legend_psy_helmet} 1, 0

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_sim_5.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/jupiter/smart/jup_sim_5.ltx
@@ -11,5 +11,5 @@ spawn_stalker_c
 
 
 [spawn_stalker_c]
-spawn_squads = stalker_sim_squad_advanced, killer_sim_squad_advanced, freedom_sim_squad_advanced, renegade_sim_squad_alpha, zombied_sim_squad_advanced, zombied_sim_squad_veteran, greh_sim_squad_veteran, monolith_sim_squad_veteran
+spawn_squads = stalker_sim_squad_advanced, merc_sim_squad_advanced, freedom_sim_squad_advanced, renegade_sim_squad_alpha, zombied_sim_squad_advanced, zombied_sim_squad_veteran, greh_sim_squad_veteran, monolith_sim_squad_veteran
 spawn_num = {+living_legend_psy_helmet} 2, 0

--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/pripyat/smart/pri_b302.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. NPC Spawns/gamedata/configs/scripts/pripyat/smart/pri_b302.ltx
@@ -10,5 +10,5 @@ respawn_idle = 42000
 spawn_stalker@advanced
 
 [spawn_stalker@advanced]
-spawn_squads = stalker_sim_squad_advanced, ecolog_sim_squad_advanced, freedom_sim_squad_advanced, duty_sim_squad_advanced, army_sim_squad_advanced, killer_sim_squad_advanced, monolith_sim_squad_advanced, greh_sim_squad_advanced, isg_sim_squad_advanced
+spawn_squads = stalker_sim_squad_advanced, ecolog_sim_squad_advanced, freedom_sim_squad_advanced, duty_sim_squad_advanced, army_sim_squad_advanced, merc_sim_squad_advanced, monolith_sim_squad_advanced, greh_sim_squad_advanced, isg_sim_squad_advanced
 spawn_num = {+living_legend_psy_helmet} 2, 0


### PR DESCRIPTION
## Problem

Four NPC Spawns smart terrains list `killer_sim_squad_advanced` in their respawn `spawn_squads`, but no active mod defines that section. Dux's Innemurable Characters Kit defines the merc warfare tiers as `merc_sim_squad_novice/advanced/veteran`, and the legacy merc squads under the original faction key as `killer_sim_squad_alpha/dead/special`. The hybrid `killer_sim_squad_advanced` exists nowhere.

When the smart respawns and the engine rolls that entry, it raises:

```
!ERROR: alife_create | section [killer_sim_squad_advanced] is invalid!
```

`sim_board.create_squad` then indexes the nil result and the game hard-crashes:

```
sim_board.script:140: attempt to index local 'squad' (a nil value)
FATAL ERROR ... CScriptEngine::lua_pcall_failed
```

The caller-side nil-guard in `smart_terrain.try_respawn` (`if (squad) ... else printe ... return`) is never reached, because the fault happens inside `create_squad` before it returns. So the only fix is the config.

## Fix

Replace `killer_sim_squad_advanced` with the correct merc advanced-tier section `merc_sim_squad_advanced` in:

- `jupiter/smart/jup_b32.ltx` (`spawn_stalker_c`)
- `jupiter/smart/jup_b46.ltx` (`spawn_stalker_c`)
- `jupiter/smart/jup_sim_5.ltx` (`spawn_stalker_c`)
- `pripyat/smart/pri_b302.ltx` (`spawn_stalker@advanced`)

NPC Spawns already uses `merc_sim_squad_advanced` correctly in 16 other smart terrains; these 4 were the only occurrences of the invalid hybrid. Same class of fix as #716 (`duty_sim_squad_alpha` -> `dolg_sim_squad_alpha`).
