### PR TITLE
Bullet tracer color indicates ammo type

### DIFF
--- a/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/configs/mod_system_ammo_tracers_oleh.ltx
+++ b/G.A.M.M.A/modpack_addons/G.A.M.M.A. Close Quarter Combat/gamedata/configs/mod_system_ammo_tracers_oleh.ltx
@@ -1,0 +1,439 @@
+; ammo type based tracer colors
+; oleh5230, 07.09.26
+; credits: Markuzkiller
+
+![ammo_base]
+4to1_tracer                              = false
+tracer_color_ID                          = 0
+tracer                                   = on
+
+![bullet_manager]
+; fire_circle_k = 0.1f ; size of fire circle on tracer tip, mainly visible when shooting while aiming with a scope; radius = fire_circle_k * tracer_width I think
+; tracer_width = 0.08
+; tracer_length_max = 225
+; tracer_length_min = 1.6
+
+![tracers_color_table]
+color_0 = 255, 180, 0, 255 ; Yellow (base)
+color_1 = 25, 255, 64, 255 ; Green (high penetration)
+color_2 = 255, 51, 119, 255 ; Red (high damage)
+color_3 = 255, 195, 77, 255 ; Orange (helicopters)
+
+![ammo_12x70_buck]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_12x70_buck_bad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_12x70_buck_verybad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_12x76_zhekan]
+tracer_color_ID	= 0
+
+![ammo_12x76_zhekan_bad]
+tracer_color_ID	= 0
+
+![ammo_12x76_zhekan_verybad]
+tracer_color_ID	= 0
+
+![ammo_12x76_bull]
+tracer_color_ID	= 1
+
+![ammo_12x76_dart]
+tracer_color_ID	= 1
+
+![ammo_12x76_dart_bad]
+tracer_color_ID	= 1
+
+![ammo_12x76_dart_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_9x18_fmj]
+tracer_color_ID	= 0
+
+![ammo_9x18_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_9x18_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_9x18_pmm]
+tracer_color_ID	= 2
+
+![ammo_9x18_pmm_bad]
+tracer_color_ID	= 2
+
+![ammo_9x18_pmm_verybad]
+tracer_color_ID	= 2
+
+![ammo_9x18_ap]
+tracer_color_ID	= 1
+
+![ammo_9x18_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_9x18_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_9x19_fmj]
+tracer_color_ID	= 0
+
+![ammo_9x19_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_9x19_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_9x19_pbp]
+tracer_color_ID	= 2
+
+![ammo_9x19_pbp_bad]
+tracer_color_ID	= 2
+
+![ammo_9x19_pbp_verybad]
+tracer_color_ID	= 2
+
+![ammo_9x19_ap]
+tracer_color_ID	= 1
+
+![ammo_9x19_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_9x19_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_5.7x28_ss190]
+tracer_color_ID	= 1
+
+![ammo_5.7x28_ss190_bad]
+tracer_color_ID	= 1
+
+![ammo_5.7x28_ss190_verybad]
+tracer_color_ID	= 1
+
+![ammo_5.7x28_ss195]
+tracer_color_ID	= 0
+
+![ammo_5.7x28_ss195_bad]
+tracer_color_ID	= 0
+
+![ammo_5.7x28_ss195_verybad]
+tracer_color_ID	= 0
+
+
+![ammo_7.62x25_p]
+tracer_color_ID	= 2
+
+![ammo_7.62x25_p_bad]
+tracer_color_ID	= 2
+
+![ammo_7.62x25_p_verybad]
+tracer_color_ID	= 2
+
+![ammo_7.62x25_ps]
+tracer_color_ID	= 0
+
+![ammo_7.62x25_ps_bad]
+tracer_color_ID	= 0
+
+![ammo_7.62x25_ps_verybad]
+tracer_color_ID	= 0
+
+
+![ammo_11.43x23_fmj]
+tracer_color_ID	= 0
+
+![ammo_11.43x23_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_11.43x23_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_11.43x23_hydro]
+tracer_color_ID	= 2
+
+![ammo_11.43x23_hydro_bad]
+tracer_color_ID	= 2
+
+![ammo_11.43x23_hydro_verybad]
+tracer_color_ID	= 2
+
+
+![ammo_5.45x39_fmj]
+tracer_color_ID	= 0
+
+![ammo_5.45x39_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_5.45x39_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_5.45x39_ep]
+tracer_color_ID	= 2
+
+![ammo_5.45x39_ep_bad]
+tracer_color_ID	= 2
+
+![ammo_5.45x39_ep_verybad]
+tracer_color_ID	= 2
+
+![ammo_5.45x39_ap]
+tracer_color_ID	= 1
+
+![ammo_5.45x39_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_5.45x39_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_5.56x45_fmj]
+tracer_color_ID	= 0
+
+![ammo_5.56x45_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_5.56x45_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_5.56x45_ss190]
+tracer_color_ID	= 2
+
+![ammo_5.56x45_ss190_bad]
+tracer_color_ID	= 2
+
+![ammo_5.56x45_ss190_verybad]
+tracer_color_ID	= 2
+
+![ammo_5.56x45_ap]
+tracer_color_ID	= 1
+
+![ammo_5.56x45_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_5.56x45_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_9x39_pab9]
+tracer_color_ID	= 0
+
+![ammo_9x39_pab9_bad]
+tracer_color_ID	= 0
+
+![ammo_9x39_pab9_verybad]
+tracer_color_ID	= 0
+
+![ammo_9x39_ap]
+tracer_color_ID	= 1
+
+![ammo_9x39_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_9x39_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_7.62x39_fmj]
+tracer_color_ID	= 0
+
+![ammo_7.62x39_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_7.62x39_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_7.62x39_ap]
+tracer_color_ID	= 1
+
+![ammo_7.62x39_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_7.62x39_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_7.92x33_fmj]; 7.92x57 German with mild steel
+tracer_color_ID	= 0
+
+![ammo_7.92x33_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_7.92x33_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_7.92x33_ap]; 7.92x57 SA AP
+tracer_color_ID	= 1
+
+![ammo_7.92x33_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_7.92x33_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_7.62x51_fmj]
+tracer_color_ID	= 0
+
+![ammo_7.62x51_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_7.62x51_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_7.62x51_ap]
+tracer_color_ID	= 1
+
+![ammo_7.62x51_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_7.62x51_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_pkm_100]; 57-N-323S belt
+tracer_color_ID	= 0
+
+![ammo_pkm_100_bad]
+tracer_color_ID	= 0
+
+![ammo_pkm_100_verybad]
+tracer_color_ID	= 0
+
+
+![ammo_7.62x54_7h1]
+tracer_color_ID	= 0
+
+![ammo_7.62x54_7h1_bad]
+tracer_color_ID	= 0
+
+![ammo_7.62x54_7h1_verybad]
+tracer_color_ID	= 0
+
+![ammo_7.62x54_ap]; 7N13
+tracer_color_ID	= 1
+
+![ammo_7.62x54_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_7.62x54_ap_verybad]
+tracer_color_ID	= 1
+
+![ammo_7.62x54_7h14]
+tracer_color_ID	= 0
+
+![ammo_7.62x54_7h14_bad]
+tracer_color_ID	= 0
+
+1[ammo_7.62x54_7h14_verybad]
+tracer_color_ID	= 0
+
+
+![ammo_12.7x55_fmj]
+tracer_color_ID	= 0
+
+![ammo_12.7x55_fmj_bad]
+tracer_color_ID	= 0
+
+![ammo_12.7x55_fmj_verybad]
+tracer_color_ID	= 0
+
+![ammo_12.7x55_ap]
+tracer_color_ID	= 1
+
+![ammo_12.7x55_ap_bad]
+tracer_color_ID	= 1
+
+![ammo_12.7x55_ap_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_magnum_300]; Lapua .338
+tracer_color_ID	= 1
+
+![ammo_magnum_300_bad]
+tracer_color_ID	= 1
+
+![ammo_magnum_300_verybad]
+tracer_color_ID	= 1
+
+
+![ammo_357_hp_mag]
+tracer_color_ID	= 2
+
+![ammo_357_hp_mag_bad]
+tracer_color_ID	= 2
+
+![ammo_357_hp_mag_verybad]
+tracer_color_ID	= 2
+
+
+![ammo_50_bmg]
+tracer_color_ID	= 0
+
+![ammo_50_bmg_bad]
+tracer_color_ID	= 0
+
+![ammo_50_bmg_verybad]
+tracer_color_ID	= 0
+
+
+; BAS
+
+![ammo_20x70_buck]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_20x70_buck_bad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_20x70_buck_verybad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_23x75_barrikada]
+tracer_color_ID	= 1
+
+![ammo_23x75_barrikada_bad]
+tracer_color_ID	= 1
+
+![ammo_23x75_barrikada_verybad]
+tracer_color_ID	= 1
+
+![ammo_23x75_shrapnel]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_23x75_shrapnel_bad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_23x75_shrapnel_verybad]
+tracer_color_ID	= 0
+tracer = off
+
+![ammo_9x21_sp10]
+tracer_color_ID	= 0
+
+![ammo_9x21_sp10_bad]
+tracer_color_ID	= 0
+
+![ammo_9x21_sp10_verybad]
+tracer_color_ID	= 0
+
+![ammo_338_federal]
+tracer_color_ID	= 2
+
+![ammo_338_federal_bad]
+tracer_color_ID	= 2
+
+![ammo_338_federal_verybad]
+tracer_color_ID	= 2


### PR DESCRIPTION
why not, especially since GAMMA HUD lacks ammo type indicator.
Would be even more useful if I figure out how to make NPC tracers visible. 